### PR TITLE
Added portable temporary directory default.

### DIFF
--- a/src/datalevin/storage.clj
+++ b/src/datalevin/storage.clj
@@ -414,7 +414,7 @@
   ([dir]
    (open dir nil))
   ([dir schema]
-   (let [dir  (or dir (str "/tmp/datalevin-" (UUID/randomUUID)))
+   (let [dir  (or dir (u/tmp-dir (str "datalevin-" (UUID/randomUUID))))
          lmdb (lmdb/open-lmdb dir)]
      (lmdb/open-dbi lmdb c/eav c/+max-key-size+ Long/BYTES)
      (lmdb/open-dbi lmdb c/aev c/+max-key-size+ Long/BYTES)

--- a/src/datalevin/util.cljc
+++ b/src/datalevin/util.cljc
@@ -1,7 +1,17 @@
 (ns ^:no-doc datalevin.util
   (:require [clojure.walk]
-            [taoensso.nippy :as nippy])
+            [taoensso.nippy :as nippy]
+            #?(:clj [clojure.java.io :as io])
+            )
   (:refer-clojure :exclude [seqable?]))
+
+(def +tmp+
+  #?(:clj (System/getProperty "java.io.tmpdir")
+     :default "/tmp/"))
+
+(defn tmp-dir
+  ([] +tmp+)
+  ([dir] (str +tmp+ dir)))
 
 ;; ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Addresses #20, works on windows, should be identical to existing behavior on linux/osx.  There are places throughout the benchmark and example code where invocations are hard coded to "/tmp" , which could be changed out with u/tmp-dir if desired.