### PR TITLE
Hopefully final fix to minor portability issue

### DIFF
--- a/src/datalevin/util.cljc
+++ b/src/datalevin/util.cljc
@@ -1,16 +1,30 @@
 (ns ^:no-doc datalevin.util
   (:require [clojure.walk]
-            [taoensso.nippy :as nippy])
-  (:import [java.io File]
-           [java.lang System])
+            [taoensso.nippy :as nippy]
+            [clojure.string :as s])
+  #?(:clj
+     (:import [java.io File]
+              [java.lang System]))
   (:refer-clojure :exclude [seqable?]))
 
+(def  +separator+
+  #?(:clj  java.io.File/separator
+     ;;this is faulty, since we could in node.js
+     ;;on windows...but it will work for now!
+     :cljs "/"))
+
 (def +tmp+
-  (or (System/getProperty "java.io.tmpdir") "/tmp"))
+  (let [path #?(:clj (System/getProperty "java.io.tmpdir")
+               :default "/tmp/")]
+    (if-not (s/ends-with? path +separator+)
+      (str path +separator+)
+      path)))
 
 (defn tmp-dir
+  "Given a directory name as a string, returns an platform
+   neutral temporary directory path."
   ([] +tmp+)
-  ([dir] (str +tmp+ File/separator dir)))
+  ([dir] (str +tmp+ dir)))
 
 ;; ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Result of previous PR merge unintentionally broke windows support and fixed linux :)
The problem was that windows path is returned with a separator at the end, while linux (and assumably osx) is not.
The merged PR inject an additional separator into the tmp-dir function, which created a duplicate separator on windows, but
corrected the behavior on linux.

This patch normalizes the return for value of +tmp+ to ensure it has a separator at the end, and just turns tmp-dir into a function that appends the directory name to +tmp+.  We could do fancy portable path parsing, but it seems easier to constrain the function to expect a single directory name as opposed to a possible non-portable path.

For the sake of cljc portability, I also wrapped the existing java stuff in reader conditionals and provided defaults.  To be truly portable, the only corner case that isn't covered is node.js on windows running cljs datalevin.  That can probably wait until someone complains about it, since it requires additional imports and detecting if you're on node or the browser, and I am not familiar with that.

behavior on linux:

`
user=>` (require 'datalevin.util)
nil
user=> (datalevin.util/tmp-dir "joinr")
"/tmp/joinr"
`

behavior on windows:

`
user=> (require 'datalevin.util)
nil
user=> (datalevin.util/tmp-dir "joinr")
"C:\\Users\\joinr\\AppData\\Local\\Temp\\joinr"
`

Verified that databases invoked via (datlevin.core/empty-db nil nil) are created in the temporary folder on both systems.
