### PR TITLE
Create a GH-Action for Building DataLevin Native on OSX & Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build datalevin native
+
+on:
+  push:
+    branches: [ main. master, ghaction ]
+  pull_request:
+    branches: [ main, master, ghaction ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        gu-binary: [gu, gu.cmd]
+        exclude:
+          - os: ubuntu-latest
+            gu-binary: gu.cmd
+          - os: macos-latest
+            gu-binary: gu.cmd
+          - os: windows-latest
+            gu-binary: gu
+        
+    steps:
+      - uses: actions/checkout@v2 
+
+      - name: Setup Graalvm
+        uses: DeLaGuardo/setup-graalvm@master
+        with:
+          graalvm-version: '21.0.0.java11'
+
+
+      - name: Install Native Image
+        run: |
+          gu install native-image
+
+
+      - name: Install LMDB
+        uses: knicknic/os-specific-run@v1.0.3
+        with:
+          macos: brew install lmdb leiningen
+          linux: sudo apt install liblmdb-dev
+
+
+      - name: Build datalevin
+        run: |
+          gu install native-image
+          cd native
+          bash script/compile


### PR DESCRIPTION
Hi @huahaiy,

I saw your blog post on compiling Datalevin with GraalVM and I am quite impressed.  In response, I've rigged up a GH action that you might find useful that builds Datalevin native for mac/linux. Right now this script only builds the binaries but it would be straightforward to auto-deposit built binaries if its  useful to you.

Previous Successful Build:  [Here](https://github.com/zachcp/datalevin/runs/1884595817?check_suite_focus=true)

zach cp

