### PR TITLE
add token filters and regexp-tokenizer

### DIFF
--- a/src/datalevin/core.cljc
+++ b/src/datalevin/core.cljc
@@ -2,6 +2,7 @@
   "User facing API for Datalevin library features"
   (:require
    [#?(:cljs cljs.reader :clj clojure.edn) :as edn]
+   [clojure.string :as str]
    [datalevin.util :as u]
    [datalevin.remote :as r]
    [datalevin.search :as sc]
@@ -21,7 +22,9 @@
    [datalevin.db DB]
    [datalevin.datom Datom]
    [datalevin.remote DatalogStore KVStore]
-   [java.util UUID]))
+   [java.util UUID]
+   [org.eclipse.collections.impl.list.mutable FastList]
+   [java.text Normalizer Normalizer$Form]))
 
 (if (u/graal?)
   (require 'datalevin.binding.graal)
@@ -1293,6 +1296,9 @@ the `pred`.
      the term in the document. E.g. for a blank space analyzer and the document
     \"The quick brown fox jumps over the lazy dog\", [\"quick\" 1 4] would be
     the second entry of the resulting seq.
+   * `:query-analyzer` is a similar function that overrides the analyzer at
+    query time (and not indexing time). Mostly useful for autocomplete search in
+    conjunction with the `prefix-token-filter`.
   "
   ([lmdb]
    (new-search-engine lmdb nil))
@@ -1371,6 +1377,101 @@ words.
        :doc      "Commit writes to search index, must be called after writing
 all documents."}
   commit sc/commit)
+
+(defn create-analyzer
+  "Creates an analyzer fn ready for use in search.
+
+  `opts` have the following keys:
+
+  * `:tokenizer` is a tokenizing fn that takes a string and returns a seq of
+  [term, position, offset], where term is a word, position is the sequence
+  number of the term, and offset is the character offset of this term.
+  `create-regexp-tokenizer` produces such fn.
+
+  * `:token-filters` is an ordered list of token filters. A token filter
+  receives a token [term, position, offset] and returns a transformed list of
+  tokens to replace it with."
+  [{:keys [tokenizer token-filters]}]
+  (fn [s]
+    (let [tokens (tokenizer s)
+          filters-tx (apply comp (map #(mapcat %) token-filters))]
+      (sequence filters-tx tokens))))
+
+(defn lower-case-token-filter
+  "This token filter converts tokens to lower case."
+  [t]
+  [(update t 0 (fn [s] (str/lower-case s)))])
+
+(defn unaccent-token-filter
+  "This token filter removes accents and diacritics from tokens."
+  [t]
+  [(update t 0 (fn [s] (-> (Normalizer/normalize s Normalizer$Form/NFD)
+                           (str/replace #"[^\p{ASCII}]", ""))))])
+
+(defn en-stop-words-token-filter
+  "This token filter removes \"empty\" tokens (for english language)."
+  [t]
+  (if (c/en-stop-words? (first t)) [] [t]))
+
+(defn prefix-token-filter
+  "Produces a series of every possible prefixes in a token and replace it with them.
+
+  For example: vault -> v, va, vau, vaul, vault
+
+  This is useful for producing efficient autocomplete engines, provided this
+  filter is NOT applied at query time."
+  [[^String word pos start]]
+  (for [idx (range 1 (inc (.length word)))]
+    [(subs word 0 idx) pos start]))
+
+(defn create-ngram-token-filter
+  "Produces character ngrams between min and max size from the token and returns
+  everything as tokens. This is useful for producing efficient fuzzy search."
+  ([min-gram-size max-gram-size]
+   (fn [[^String word pos start]]
+     (let [length (.length word)]
+       (loop [idx 0
+              gram-size min-gram-size
+              ngrams (transient [word])]
+         (if (or (= idx length) (< length (+ idx gram-size)))
+           (persistent! ngrams)
+           (if-not (< gram-size max-gram-size)
+             (recur (inc idx) min-gram-size (conj! ngrams
+                                                   [(subs word idx (min (+ idx gram-size) length)) pos start]))
+             (recur idx (inc gram-size) (conj! ngrams
+                                               [(subs word idx (min (+ idx gram-size) length)) pos start]))))))))
+  ([gram-size] (ngram-token-filter gram-size gram-size)))
+
+(defn create-min-length-token-filter
+  "Filters tokens that are strictly shorter than `min-length`."
+  [min-length]
+  (fn [[^String word _ _ :as t]] (if (< (.length word) min-length) [] [t])))
+
+(defn create-max-length-token-filter
+  "Filters tokens that are strictly longer than `max-length`."
+  [max-length]
+  (fn [[^String word _ _ :as t]] (if (> (.length word) max-length) [] [t])))
+
+(defn create-regexp-tokenizer
+  "Creates a tokenizer that splits the given text on the pattern given as
+  argument, and returns valid tokens."
+  [pat]
+  (fn [^String s]
+    (let [matcher (re-matcher pat s)
+          res (FastList.)
+          string-end (.length s)]
+      (loop [pos 0
+             last-separator-end 0]
+        (if (.find matcher)
+          (let [match-start (.start matcher)
+                match-end (.end matcher)
+                token (subs s last-separator-end match-start)]
+            (.add res [token pos last-separator-end])
+            (recur (inc pos) match-end))
+          (when (not= last-separator-end string-end)
+            (let [token (subs s last-separator-end string-end)]
+              (.add res [token pos last-separator-end])))))
+      res)))
 
 ;; -------------------------------------
 ;; byte buffer

--- a/src/datalevin/search.clj
+++ b/src/datalevin/search.clj
@@ -417,6 +417,7 @@
 
 (deftype ^:no-doc SearchEngine [lmdb
                                 analyzer
+                                query-analyzer
                                 ^IntShortHashMap norms ; doc-id -> norm
                                 ^AtomicInteger max-doc
                                 ^AtomicInteger max-term]
@@ -453,7 +454,7 @@
                        :or   {display    :refs
                               top        10
                               doc-filter (constantly true)}}]
-    (let [tokens (->> (analyzer query)
+    (let [tokens (->> (query-analyzer query)
                       (mapv first)
                       (into-array String))
           qterms (->> (hydrate-query lmdb max-doc tokens)
@@ -515,11 +516,12 @@
 (defn new-search-engine
   ([lmdb]
    (new-search-engine lmdb nil))
-  ([lmdb {:keys [analyzer]
+  ([lmdb {:keys [analyzer query-analyzer]
           :or   {analyzer en-analyzer}}]
    (open-dbis lmdb)
    (->SearchEngine lmdb
                    analyzer
+                   (or query-analyzer analyzer)
                    (init-norms lmdb)
                    (AtomicInteger. (init-max-doc lmdb))
                    (AtomicInteger. (init-max-term lmdb)))))

--- a/test/datalevin/core_test.cljc
+++ b/test/datalevin/core_test.cljc
@@ -4,6 +4,7 @@
             [datalevin.client :as cl]
             [datalevin.interpret :as i]
             [datalevin.constants :as c]
+            [datalevin.search :as sc]
             [datalevin.util :as u]
             [datalevin.test.core]
             [clojure.string :as str]
@@ -771,6 +772,33 @@
       (is (= (sut/search engine "red" ) [2])))
     (sut/close-kv lmdb)
     (s/stop server)))
+
+(deftest custom-analyzer-test
+  (let [s1 "This is a Datalevin-Analyzers test"
+        s2 "This is a Datalevin-Analyzers test. "
+        cust-analyzer-en (sut/create-analyzer
+                          {:tokenizer (sut/create-regexp-tokenizer
+                                       #"[\s:/\.;,!=?\"'()\[\]{}|<>&@#^*\\~`]+")
+                           :token-filters [sut/lower-case-token-filter
+                                           sut/en-stop-words-token-filter]})]
+    (is (fn? cust-analyzer-en))
+    (is (= (sc/en-analyzer s1)
+           (cust-analyzer-en s1)
+           (cust-analyzer-en s2)
+           [["datalevin-analyzers" 3 10] ["test" 4 30]]))))
+
+(deftest autocomplete-analyzer-test
+  (let [s1 "clock"
+        s2 "cloud"
+        cust-analyzer-en (sut/create-analyzer
+                          {:tokenizer (sut/create-regexp-tokenizer
+                                       #"[\s:/\.;,!=?\"'()\[\]{}|<>&@#^*\\~`]+")
+                           :token-filters [sut/lower-case-token-filter
+                                           sut/prefix-token-filter]})]
+    (is (= (into [] (cust-analyzer-en s1))
+           [["c" 0 0] ["cl" 0 0] ["clo" 0 0] ["cloc" 0 0] ["clock" 0 0]]))
+    (is (= (into [] (cust-analyzer-en s2))
+           [["c" 0 0] ["cl" 0 0] ["clo" 0 0] ["clou" 0 0] ["cloud" 0 0]]))))
 
 (deftest remote-blank-analyzer-test
   (let [server         (s/create {:port c/default-port


### PR DESCRIPTION
In addition to the tools functions, this adds a `:query-analyzer` in addition to `analyzer` without breaking compatibility, mostly because it is absolutely needed to support efficient autocomplete, and I think it is a great possible application for datalevin...

A remaining problem here is that, from my reading of the code `inter-fn` cannot nest right now, which means you cannot use fn producing inter-fn (like `create-ngram-token-filter`) in `create-analyzer` and have it work in client - server. Also, datalevin.core cannot require datalevin.interpret, so we would need to move these fns to another ns to avoid the circular dependency I guess... What do you think?

resolves #105 