### PR TITLE
Add cljdoc config/adjustments

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,10 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.md"}]
+  ["Changelog" {:file "CHANGELOG.md"}]
+  ["Command Line Tool" {:file "doc/dtlv.md"}]
+  ["Search Engine" {:file "doc/search.md"}]
+  ["Database Upgrade" {:file "doc/upgrade.md"}]
+  ["Server/Client" {:file "doc/server.md"}]
+  ["Benchmark" {:file "bench/README.md"}]
+  ["Graal Native" {:file "native/README.md"}]]
+ :cljdoc/languages ["clj"]}

--- a/src/datalevin/binding/graal.clj
+++ b/src/datalevin/binding/graal.clj
@@ -1,4 +1,4 @@
-(ns datalevin.binding.graal
+(ns ^:no-doc datalevin.binding.graal
   "LMDB binding for GraalVM native image"
   (:require [datalevin.bits :as b]
             [datalevin.util :refer [raise] :as u]

--- a/src/datalevin/constants.cljc
+++ b/src/datalevin/constants.cljc
@@ -1,4 +1,4 @@
-(ns datalevin.constants
+(ns ^:no-doc datalevin.constants
   (:refer-clojure :exclude [meta])
   (:require [taoensso.nippy :as nippy])
   (:import [java.util UUID Arrays HashSet]))

--- a/src/datalevin/datafy.cljc
+++ b/src/datalevin/datafy.cljc
@@ -1,4 +1,4 @@
-(ns datalevin.datafy
+(ns ^:no-doc datalevin.datafy
   (:require [clojure.core.protocols :as cp]
             [datalevin.pull-api :as dp]
             [datalevin.db :as db]

--- a/src/datalevin/lmdb.cljc
+++ b/src/datalevin/lmdb.cljc
@@ -1,4 +1,4 @@
-(ns datalevin.lmdb
+(ns ^:no-doc datalevin.lmdb
   "API for LMDB Key Value Store"
   (:require [datalevin.util :as u]))
 

--- a/src/datalevin/protocol.clj
+++ b/src/datalevin/protocol.clj
@@ -1,4 +1,4 @@
-(ns datalevin.protocol
+(ns ^:no-doc datalevin.protocol
   "Shared code of client/server"
   (:require [datalevin.bits :as b]
             [datalevin.constants :as c]

--- a/src/datalevin/remote.clj
+++ b/src/datalevin/remote.clj
@@ -1,4 +1,4 @@
-(ns datalevin.remote
+(ns ^:no-doc datalevin.remote
   "Proxy for remote stores"
   (:require [datalevin.util :as u]
             [datalevin.constants :as c]

--- a/src/datalevin/sparselist.clj
+++ b/src/datalevin/sparselist.clj
@@ -1,4 +1,4 @@
-(ns datalevin.sparselist
+(ns ^:no-doc datalevin.sparselist
   "Sparse array list of integers"
   (:refer-clojure :exclude [get set remove])
   (:import [java.nio ByteBuffer]

--- a/src/pod/huahaiy/datalevin.clj
+++ b/src/pod/huahaiy/datalevin.clj
@@ -1,4 +1,4 @@
-(ns pod.huahaiy.datalevin
+(ns ^:no-doc pod.huahaiy.datalevin
   (:refer-clojure :exclude [read read-string])
   (:require [bencode.core :as bencode]
             [sci.core :as sci]


### PR DESCRIPTION
Was previously failing on cljdoc because cljdoc assumed it should do
ClojureScript analysis because it a saw .cljc files.
Told cljdoc only Clojure should be analyzed in doc/cljdoc.edn.

I noticed codox config (which cljdoc does not look at) includes some
specific namespaces to document but existing code has some :no-doc
metadata already.

So made bold assumptions:

Always document codox specified namespaces:
- datalevin.client
- datalevin.core
- datalevin.interpret
- datalevin.search-utils

Else if namespace contains no :no-doc anywhere assume it should not be
documented and :no-doc added to namespace:
- datalevin.binding.graal
- datalevin.constants
- datalevin.datafy
- datalevin.lmdb
- datalevin.protocol
- datalevin.remote
- datalevin.sparelist
- pod.huahaiy.datalevin

My assumption was that if there is some var(s) with a :no-doc in a
namespace without a :no-doc, the namespace wants to be documented.
This added the following to API docs:
- datalevin.bits
- datelevin.main
- datalevin.search
- datalevin.server

Also added all .md docs I found to cljdoc list of articles.
This adds:
- bench/README.md
- native/README.md

The above could be entirely wrong, am happy to refine with you.