### PR TITLE
Adding `entity` to exposed pod functions

### DIFF
--- a/src/pod/huahaiy/datalevin.clj
+++ b/src/pod/huahaiy/datalevin.clj
@@ -367,6 +367,7 @@
    'update-schema      update-schema
    'get-conn           get-conn
    'q                  q
+   'entity             entity
    'open-kv            open-kv
    'close-kv           close-kv
    'closed-kv?         closed-kv?


### PR DESCRIPTION
`entity` fn is missing from the list of exposed pod functions