### PR TITLE
Remove the --verbose from native properties file 

### DIFF
--- a/native/resources/META-INF/native-image/org.clojars.huahaiy/datalevin-native/native-image.properties
+++ b/native/resources/META-INF/native-image/org.clojars.huahaiy/datalevin-native/native-image.properties
@@ -7,7 +7,6 @@ Args=-H:+ReportExceptionStackTraces \
     -J-Dclojure.compiler.direct-linking=true \
     --report-unsupported-elements-at-runtime \
     --allow-incomplete-classpath \
-    --verbose \
     --no-fallback \
     --no-server \
     --native-image-info


### PR DESCRIPTION
the `--verbose` option in the file generates an error in recent version of native builder, as it should only be specified on the command line. This breaks compilation. Removing the switch from the properties file fixes the problem, and is backward compatible with older versions (at least in the sense that compilation won't break).