### PR TITLE
fix caching issue with timeouts

### DIFF
--- a/src/datalevin/parser.cljc
+++ b/src/datalevin/parser.cljc
@@ -696,7 +696,7 @@
 ;; query
 
 ;; q* prefix because of https://dev.clojure.org/jira/browse/CLJS-2237
-(deftrecord Query [qfind qwith return-map qin qwhere qdeadline])
+(deftrecord Query [qfind qwith return-map qin qwhere qtimeout])
 
 (defn query->map [query]
   (loop [parsed {}, key nil, qs query]
@@ -788,7 +788,7 @@
 (defn parse-timeout [t]
   (cond
     (sequential? t) (recur (first t))
-    (number? t) (timeout/to-deadline t)
+    (number? t) t
     (nil? t) nil
     :else (raise "Unsupported timeout format"
             {:error :parser/query :form t})))
@@ -810,6 +810,6 @@
                   :qin         (parse-in
                                  (or (:in qm) (default-in qwhere)))
                   :qwhere      qwhere
-                  :qdeadline   (parse-timeout (:timeout qm))})]
+                  :qtimeout   (parse-timeout (:timeout qm))})]
     (validate-query res q qm)
     res))

--- a/src/datalevin/query.cljc
+++ b/src/datalevin/query.cljc
@@ -1178,8 +1178,8 @@
         find-vars     (dp/find-vars find)
         result-arity  (count find-elements)
         with          (:qwith parsed-q)
-        deadline      (:qdeadline parsed-q)]
-    (binding [timeout/*deadline* deadline]
+        timeout      (:qtimeout parsed-q)]
+    (binding [timeout/*deadline* (timeout/to-deadline timeout)]
       (let [;; TODO utilize parser
             all-vars      (concat find-vars (map :symbol with))
             q             (cond-> q


### PR DESCRIPTION
timeouts used to compute deadlines (absolute instants) at parsing time.... and this gets cached. I modified the code so that timeouts are not converted to deadlines at parsing time.