### PR TITLE
fix print method

### DIFF
--- a/src/datalevin/db.cljc
+++ b/src/datalevin/db.cljc
@@ -274,12 +274,12 @@
 
 (defmethod print-method DB [^DB db, ^java.io.Writer w]
   (binding [*out* w]
-    (let [store (:dtore db)]
+    (let [{:keys [store eavt max-eid max-tx]} db]
       (pr {:db-name       (s/db-name store)
            :last-modified (s/last-modified store)
-           :datom-count   (count :eavt)
-           :max-eid       (:max-eid db)
-           :max-tx        (:max-tx db)}))))
+           :datom-count   (count eavt)
+           :max-eid       max-eid
+           :max-tx        max-tx}))))
 
 (defn db?
   "Check if x is an instance of DB, also refresh its cache if it's stale.


### PR DESCRIPTION
This fixes two typos in `DB`s `print-method` that lead to an error printing db at the REPL or serializing stack traces:

```clojure
@conn
Error printing return value (IllegalArgumentException) at clojure.core/-cache-protocol-fn (core_deftype.clj:584).
No implementation of method: :db-name of protocol: #'datalevin.storage/IStore found for class: nil
```