### PR TITLE
Create dynamic var for data readers

### DIFF
--- a/src/datalevin/main.clj
+++ b/src/datalevin/main.clj
@@ -46,15 +46,18 @@
 
 ;; Data Readers
 
-(def data-readers {'datalevin/Datom    dd/datom-from-reader
-                   'datalevin/DB       db/db-from-reader
-                   'datalevin/bytes    b/bytes-from-reader
-                   'datalevin/regex    b/regex-from-reader
-                   'datalevin/inter-fn i/inter-fn-from-reader
-                   })
+(def datalevin-data-readers
+  {'datalevin/Datom    dd/datom-from-reader
+   'datalevin/DB       db/db-from-reader
+   'datalevin/bytes    b/bytes-from-reader
+   'datalevin/regex    b/regex-from-reader
+   'datalevin/inter-fn i/inter-fn-from-reader
+   })
+
+(def ^:dynamic *datalevin-data-readers* datalevin-data-readers)
 
 ;; #?(:cljs
-;;    (doseq [[tag cb] data-readers] (edn/register-tag-parser! tag cb)))
+;;    (doseq [[tag cb] datalevin-data-readers] (edn/register-tag-parser! tag cb)))
 
 (def ^:private commands
   #{"copy" "drop" "dump" "exec" "help" "load" "repl" "serv" "stat"})
@@ -418,7 +421,7 @@
   (try
     (with-open [^PushbackReader r in]
       (let [read-form     #(edn/read {:eof     ::EOF
-                                      :readers data-readers} r)
+                                      :readers *datalevin-data-readers*} r)
             read-maps     #(let [m1 (read-form)]
                              (if (:db/ident m1)
                                [nil m1]


### PR DESCRIPTION
### Rationale

This supports the use case of users who have values with tagged literals stored in their databases. Just as with `clojure.core/*data-readers*` and `clojure.core/default-data-readers`, there is also a static var containing the default readers to fall back to in contexts where the dynamic value has been rebound, which is used to initialize the dynamic var.

### Testing

Tested locally with `lein test` - no issues.

### Questions

I am not sure if the naming of `datalevin-data-readers` is unwieldy, but I named those vars like that to avoid potentially shadowing the equivalent vars from `clojure.core`. They can be renamed to something different if it would be better.