### PR TITLE
getting clojure.core redefinition warnings when requiring datalevin

### DIFF
--- a/src/datalevin/core.cljc
+++ b/src/datalevin/core.cljc
@@ -18,6 +18,7 @@
    [datalevin.built-ins :as dbq]
    [datalevin.entity :as de]
    [datalevin.bits :as b])
+  (:refer-clojure :exclude [load])
   (:import
    [datalevin.entity Entity]
    [datalevin.storage Store]

--- a/src/datalevin/lmdb.cljc
+++ b/src/datalevin/lmdb.cljc
@@ -7,6 +7,7 @@
    [datalevin.bits :as b]
    [datalevin.util :as u]
    [datalevin.constants :as c])
+  (:refer-clojure :exclude [load])
   (:import
    [java.lang RuntimeException]
    [java.io PushbackReader FileOutputStream FileInputStream DataOutputStream


### PR DESCRIPTION
```
WARNING: load already refers to: #'clojure.core/load in namespace: datalevin.lmdb, being replaced by: #'datalevin.lmdb/load
WARNING: load already refers to: #'clojure.core/load in namespace: datalevin.core, being replaced by: #'datalevin.core/load
```

for reference I am using `tool.deps` + `tools.build`, not sure if lein users have the error or not