### PR TITLE
Bugfix: xform is called for cardinality/one refs in pull

### DIFF
--- a/src/datalevin/pull_api.cljc
+++ b/src/datalevin/pull_api.cljc
@@ -71,10 +71,11 @@
         :else
         (recur (conj! acc (.-v datom)) (next-seq datoms))))))
 
-(defrecord MultivalRefAttrFrame [seen recursion-limits acc pattern ^PullAttr attr datoms]
+;; Used for both :cardinality/many and :cardinality/one ref-types
+(defrecord RefAttrFrame [seen recursion-limits acc pattern ^PullAttr attr datoms]
   IFrame
   (-merge [_ result]
-    (MultivalRefAttrFrame.
+    (RefAttrFrame.
       seen
       recursion-limits
       (conj-some! acc (.-value ^ResultFrame result))
@@ -165,7 +166,7 @@
         ;; matching attr
         (and (.-multival? attr) (.-ref? attr))
         [(AttrsFrame. seen recursion-limits acc pattern attr attrs datoms id)
-         (MultivalRefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]
+         (RefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]
 
         (.-multival? attr)
         [(AttrsFrame. seen recursion-limits acc pattern attr attrs datoms id)
@@ -173,7 +174,7 @@
 
         (.-ref? attr)
         [(AttrsFrame. seen recursion-limits acc pattern attr attrs datoms id)
-         (ref-frame context seen recursion-limits pattern attr (.-v datom))]
+         (RefAttrFrame. seen recursion-limits (transient {}) pattern attr datoms)]
 
         :else
         (recur
@@ -221,7 +222,7 @@
 
         :else
         [(ReverseAttrsFrame. seen recursion-limits acc pattern attr attrs id)
-         (MultivalRefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]))))
+         (RefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]))))
 
 (defn- auto-expanding? [^PullAttr attr]
   (or

--- a/test/datalevin/test/pull_api.cljc
+++ b/test/datalevin/test/pull_api.cljc
@@ -571,6 +571,41 @@
     (d/close-db test-db)
     (u/delete-files dir)))
 
+(deftest test-xform-cardinality-one
+  (let [dir      (u/tmp-dir (str "pull-xform-cardinality-one" (UUID/randomUUID)))
+        test-db  (d/db-with (d/empty-db dir
+                              {:statement/effect
+                               {:db/valueType :db.type/ref, :db/cardinality :db.cardinality/one}
+
+                               :statement2/effect
+                               {:db/valueType :db.type/ref}})
+                   [{:statement/effect {:effect :allow}}
+                    {:statement2/effect {:effect :deny}}])
+        tracker_ (atom 0)]
+
+    (testing "xform is called for cardinality/one ref type"
+      (is (= {:statement/effect :allow}
+            (d/pull test-db [{[:statement/effect :xform (fn [x] (swap! tracker_ inc) (:effect x))]
+                              [:effect]}]
+              1)))
+      (is (= 1 @tracker_)))
+
+    (testing "xform is called for the leaf before the parent"
+      (reset! tracker_ 0)
+      (is (= {:statement/effect {:effect :leaf :new :prop}}
+            (d/pull test-db
+              [{[:statement/effect :xform (fn [x] (swap! tracker_ inc) (assoc x :new :prop))]
+                [[:effect :xform (fn [v] (swap! tracker_ inc) :leaf)]]}]
+              1)))
+      (is (= 2 @tracker_)))
+
+    (testing "xform is called for ref with no cardinality"
+      (is (= {:statement2/effect :deny}
+            (d/pull test-db [{[:statement2/effect :xform (fn [x] (:effect x))] [:effect]}] 3))))
+
+    (d/close-db test-db)
+    (u/delete-files dir)))
+
 (deftest test-visitor
   (let [dir     (u/tmp-dir (str "pull-" (UUID/randomUUID)))
         test-db (d/init-db test-datoms dir test-schema)


### PR DESCRIPTION
Addresses https://github.com/juji-io/datalevin/issues/224

I played with the implementation for a bit and was going to add a new frame record type `SinglevalRefAttrFrame`
but then realized the existing `MultivalRefAttrFrame` would work as well because its two cond cases work for cardinality one as well, when it finds the attribute: 
https://github.com/juji-io/datalevin/blob/c55574a8749eb5e4f787840301cede7b7f3f58dd/src/datalevin/pull_api.cljc#L88C10-L88C10

and when it doesn't https://github.com/juji-io/datalevin/blob/c55574a8749eb5e4f787840301cede7b7f3f58dd/src/datalevin/pull_api.cljc#L102 

- this last else is the same as the current version of pull which just calls `ref-frame` for a cardinality-one reference [here](https://github.com/juji-io/datalevin/blob/c55574a8749eb5e4f787840301cede7b7f3f58dd/src/datalevin/pull_api.cljc#L176).

That, and using a hashmap for `acc` would suffice to get this working. The xform is actually called here:

https://github.com/juji-io/datalevin/blob/c55574a8749eb5e4f787840301cede7b7f3f58dd/src/datalevin/pull_api.cljc#L89C11-L89C61

So I ended up using `MultivalRefAttrFrame` for both cardinality one and many and renaming it. 