### PR TITLE
Refactor xform to one refs in pull expressions

### DIFF
--- a/src/datalevin/pull_api.cljc
+++ b/src/datalevin/pull_api.cljc
@@ -58,7 +58,7 @@
         :let [^Datom datom (first-seq datoms)]
 
         (or (nil? datom) (not= (.-a datom) (.-name attr)))
-        [(ResultFrame. ((.-xform attr) (not-empty (persistent! acc))) (or datoms ()))]
+        [(ResultFrame. (not-empty (persistent! acc)) (or datoms ()))]
 
         ;; got limit, skip rest of the datoms
         (and (.-limit attr) (>= (count acc) ^long (.-limit attr)))
@@ -86,7 +86,7 @@
       :let [^Datom datom (first-seq datoms)]
 
       (or (nil? datom) (not= (.-a datom) (.-name attr)))
-      [(ResultFrame. ((.-xform attr) (not-empty (persistent! acc))) (or datoms ()))]
+      [(ResultFrame. (not-empty (persistent! acc)) (or datoms ()))]
 
       ;; got limit, skip rest of the datoms
       (and (.-limit attr) (>= (count acc) ^long (.-limit attr)))
@@ -107,7 +107,7 @@
     (AttrsFrame.
       seen
       recursion-limits
-      (assoc-some! acc (.-as attr) (.-value ^ResultFrame result))
+      (assoc-some! acc (.-as attr) ((.-xform attr) (.-value ^ResultFrame result)))
       pattern
       (first-seq attrs)
       (next-seq attrs)
@@ -188,7 +188,7 @@
     (ReverseAttrsFrame.
       seen
       recursion-limits
-      (assoc-some! acc (.-as attr) (.-value ^ResultFrame result))
+      (assoc-some! acc (.-as attr) ((.-xform attr) (.-value ^ResultFrame result)))
       pattern
       (first-seq attrs)
       (next-seq attrs)

--- a/src/datalevin/pull_api.cljc
+++ b/src/datalevin/pull_api.cljc
@@ -71,11 +71,10 @@
         :else
         (recur (conj! acc (.-v datom)) (next-seq datoms))))))
 
-;; Used for both :cardinality/many and :cardinality/one ref-types
-(defrecord RefAttrFrame [seen recursion-limits acc pattern ^PullAttr attr datoms]
+(defrecord MultivalRefAttrFrame [seen recursion-limits acc pattern ^PullAttr attr datoms]
   IFrame
   (-merge [_ result]
-    (RefAttrFrame.
+    (MultivalRefAttrFrame.
       seen
       recursion-limits
       (conj-some! acc (.-value ^ResultFrame result))
@@ -166,7 +165,7 @@
         ;; matching attr
         (and (.-multival? attr) (.-ref? attr))
         [(AttrsFrame. seen recursion-limits acc pattern attr attrs datoms id)
-         (RefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]
+         (MultivalRefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]
 
         (.-multival? attr)
         [(AttrsFrame. seen recursion-limits acc pattern attr attrs datoms id)
@@ -174,7 +173,7 @@
 
         (.-ref? attr)
         [(AttrsFrame. seen recursion-limits acc pattern attr attrs datoms id)
-         (RefAttrFrame. seen recursion-limits (transient {}) pattern attr datoms)]
+         (ref-frame context seen recursion-limits pattern attr (.-v datom))]
 
         :else
         (recur
@@ -222,7 +221,7 @@
 
         :else
         [(ReverseAttrsFrame. seen recursion-limits acc pattern attr attrs id)
-         (RefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]))))
+         (MultivalRefAttrFrame. seen recursion-limits (transient []) pattern attr datoms)]))))
 
 (defn- auto-expanding? [^PullAttr attr]
   (or

--- a/test/datalevin/test/pull_api.cljc
+++ b/test/datalevin/test/pull_api.cljc
@@ -1,10 +1,9 @@
 (ns datalevin.test.pull-api
   (:require
-    [clojure.string :as str]
-    [datalevin.test.core :as tdc :refer [db-fixture]]
-    [clojure.test :refer [deftest testing is use-fixtures]]
-    [datalevin.util :as u]
-    [datalevin.core :as d])
+   [datalevin.test.core :as tdc :refer [db-fixture]]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [datalevin.util :as u]
+   [datalevin.core :as d])
   (:import
    [java.util UUID]))
 
@@ -584,8 +583,6 @@
 
     (d/close-db test-db)
     (u/delete-files dir)))
-
-(clojure.test/run-test-var (var test-xform))
 
 (deftest test-xform-cardinality-one
   (let [dir      (u/tmp-dir (str "pull-xform-cardinality-one" (UUID/randomUUID)))


### PR DESCRIPTION
My prior fix to add support for xform of cardinality-one ref types in this PR https://github.com/juji-io/datalevin/pull/226 
doesn't work for reverse component refs, I noticed this after seeing the same issue being fixed in DataScript 
https://github.com/tonsky/datascript/commit/941c2b172d631b5aeec181837132376e818554f1
and issue https://github.com/tonsky/datascript/issues/455

This PR reverts my prior attempt at a fix and pulls in the DataScript fix.