### PR TITLE
Fix `:validate-data? true` not working for some types

### DIFF
--- a/src/datalevin/storage.cljc
+++ b/src/datalevin/storage.cljc
@@ -611,11 +611,11 @@
         e     (.-e d)
         v     (.-v d)
         aid   (:db/aid props)
+        _     (or (not (:validate-data? (opts store)))
+                (b/valid-data? v vt)
+                (u/raise "Invalid data, expecting " vt {:input v}))
         i     (b/indexable e aid v vt)
         ft?   (:db/fulltext props)]
-    (or (not (:validate-data? (opts store)))
-        (b/valid-data? v vt)
-        (u/raise "Invalid data, expecting " vt {:input v}))
     (if (b/giant? i)
       (let [max-gt (max-gt store)]
         (advance-max-gt store)


### PR DESCRIPTION
`:validate-data? true` doesn't work for some types.

Some type mismatches can cause `b/indexable` to throw an error before validation happens. This error doesn't happen when you pass a string instead of a UUID, which is why the current tests don't catch this.

This fix moves validation to be called before `b/indexable`.

I've added more tests cases to capture this issue.

Let me know if you want me to make any changes.
