### PR TITLE
Add :closed-schema? option

### DIFF
--- a/src/datalevin/core.cljc
+++ b/src/datalevin/core.cljc
@@ -217,6 +217,8 @@ Only usable for debug output.
 
    * `:validate-data?`, a boolean, instructing the system to validate data type during transaction. Default is `false`.
 
+   * `:closed-schema?`, a boolean, instructing the system to only allow entity attributes defined in the schema during transaction. Default is `false`.
+
    * `:auto-entity-time?`, a boolean indicating whether to maintain `:db/created-at` and `:db/updated-at` values for each entity. Default is `false`.
 
    * `:search-domains`, an option map from domain names to search option maps of those domains, which will be passed to the corresponding full-text search engines. See [[new-search-engine]]
@@ -273,6 +275,8 @@ Only usable for debug output.
  `opts` map has keys:
 
    * `:validate-data?`, a boolean, instructing the system to validate data type during transaction. Default is `false`.
+
+   * `:closed-schema?`, a boolean, instructing the system to only allow entity attributes defined in the schema during transaction. Default is `false`.
 
    * `:auto-entity-time?`, a boolean indicating whether to maintain `:db/created-at` and `:db/updated-at` values for each entity. Default is `false`.
 
@@ -559,6 +563,8 @@ Only usable for debug output.
 
    * `:validate-data?`, a boolean, instructing the system to validate data type during transaction. Default is `false`.
 
+   * `:closed-schema?`, a boolean, instructing the system to only allow entity attributes defined in the schema during transaction. Default is `false`.
+
    * `:auto-entity-time?`, a boolean indicating whether to maintain `:db/created-at` and `:db/updated-at` values for each entity. Default is `false`.
 
    * `:search-domains`, an option map from domain names to search option maps of those domains, which will be passed to the corresponding full-text search engines. See [[new-search-engine]]
@@ -582,6 +588,8 @@ Only usable for debug output.
   `opts` map may have keys:
 
    * `:validate-data?`, a boolean, instructing the system to validate data type during transaction. Default is `false`.
+
+   * `:closed-schema?`, a boolean, instructing the system to only allow entity attributes defined in the schema during transaction. Default is `false`.
 
    * `:auto-entity-time?`, a boolean indicating whether to maintain `:db/created-at` and `:db/updated-at` values for each entity. Default is `false`.
 
@@ -1075,6 +1083,8 @@ Only usable for debug output.
        :doc      "Open a named DBI (i.e. sub-db) in the key-value store. `opts` is an option map that may have the following keys:
 
       * `:validate-data?`, a boolean, instructing the system to validate data type during transaction. Default is `false`.
+
+      * `:closed-schema?`, a boolean, instructing the system to only allow entity attributes defined in the schema during transaction. Default is `false`.
 
       * `:key-size` is the max size of the key in bytes, cannot be greater than 511, default is 511.
 

--- a/src/datalevin/storage.cljc
+++ b/src/datalevin/storage.cljc
@@ -604,6 +604,9 @@
 (defn- insert-data
   [^Store store ^Datom d ft-ds giants]
   (let [attr  (.-a d)
+        _     (or (not (:closed-schema? (opts store)))
+                ((schema store) attr)
+                (u/raise "Entity attribute not defined in schema " attr {}))
         props (or ((schema store) attr)
                   (swap-attr store attr identity))
         vt    (value-type props)
@@ -738,8 +741,10 @@
   ([dir schema]
    (open dir schema nil))
   ([dir schema {:keys [kv-opts search-opts search-domains validate-data?
-                       auto-entity-time? db-name cache-limit]
+                       closed-schema?  auto-entity-time? db-name
+                       cache-limit]
                 :or   {validate-data?    false
+                       closed-schema?    false
                        auto-entity-time? false
                        db-name           (str (UUID/randomUUID))
                        cache-limit       100}
@@ -754,6 +759,7 @@
        (transact-opts lmdb (merge opts0
                                   opts
                                   {:validate-data?    validate-data?
+                                   :closed-schema?    closed-schema?
                                    :auto-entity-time? auto-entity-time?
                                    :db-name           db-name
                                    :cache-limit       cache-limit

--- a/test/datalevin/test/transact.cljc
+++ b/test/datalevin/test/transact.cljc
@@ -668,6 +668,20 @@
     (d/close-db db)
     (u/delete-files dir)))
 
+(deftest closed-schema
+  "closed schema during transact"
+  (let [sc  {:id      {:db/valueType :db.type/uuid}
+             :company {}}
+        dir (u/tmp-dir (str "skip-" (UUID/randomUUID)))
+        db  (d/empty-db dir sc {:closed-schema? true})]
+    (is (thrown-with-msg? Exception
+          #"Entity attribute not defined in schema :undefined-attr"
+          (d/db-with db
+            [{:db/id -1 :company "IBM" :id (random-uuid)
+              :undefined-attr "ibm"}])))
+    (d/close-db db)
+    (u/delete-files dir)))
+
 #?(:clj
    (deftest test-transact-bytes
      "requires comparing byte-arrays"


### PR DESCRIPTION
Not sure if this is something that datalevin wants to support. So feel free to close this PR if it's not something that aligns with the datalevin vision.

**Rationale**

Coming from datomic I was finding one of the first things I do when I use datalevin is add some basic schema validation to prevent transacting entity attributes that are not defined in the schema.

**Proposed solution**

This PR adds the `:closed-schema?` flag. Which can be used to prevent entity attributes that have not been defined from being transacted. This is useful when you want to prevent accidental pollution of your data and/or interact with low trust or volatile sources.

Example:

```
(let [sc {:id      {:db/valueType :db.type/uuid}
          :company {}}
      db (d/empty-db "foo" sc {:closed-schema? true})]
  (d/db-with db
    [{:db/id -1 :company "IBM" :id "ibm" :foo-bar "ibm"}])
  (d/close-db db))

user=> Execution error (ExceptionInfo) at datalevin.storage/insert-data 
Attribute not defined in schema :foo-bar
```

The entity attribute just needs to appear in the schema, the `{}` associated with it can still be empty (see `:company {}` in the above example). This means EDN blobs still work (no :db/valueType).

The `:closed-schema?` defaults to `false`.

Let me know if I need to make any changes or have missed anything.