### PR TITLE
Fix spacing in invalid data error messages

### DIFF
--- a/src/datalevin/binding/graal.clj
+++ b/src/datalevin/binding/graal.clj
@@ -195,7 +195,7 @@
   (put-key [this x t]
     (or (not validate-data?)
         (b/valid-data? x t)
-        (raise "Invalid data, expecting " t {:input x}))
+        (raise "Invalid data, expecting " t " got " x {:input x}))
     (let [^ByteBuffer kb (.inBuf kp)
           dbi-name       (.dbi-name this)]
       (try
@@ -211,7 +211,7 @@
   (put-val [this x t]
     (or (not validate-data?)
         (b/valid-data? x t)
-        (raise "Invalid data, expecting " t {:input x}))
+        (raise "Invalid data, expecting " t " got " x {:input x}))
     (let [^ByteBuffer vb (.inBuf vp)
           dbi-name       (.dbi-name this)]
       (try

--- a/src/datalevin/binding/java.clj
+++ b/src/datalevin/binding/java.clj
@@ -174,7 +174,7 @@
   (put-key [this x t]
     (or (not validate-data?)
         (b/valid-data? x t)
-        (raise "Invalid data, expecting" t {:input x}))
+        (raise "Invalid data, expecting " t " got " x {:input x}))
     (try
       (.clear kb)
       (b/put-buffer kb x t)
@@ -188,7 +188,7 @@
   (put-val [this x t]
     (or (not validate-data?)
         (b/valid-data? x t)
-        (raise "Invalid data, expecting " t {:input x}))
+        (raise "Invalid data, expecting " t " got " x {:input x}))
     (try
       (.clear vb)
       (b/put-buffer vb x t)

--- a/src/datalevin/storage.cljc
+++ b/src/datalevin/storage.cljc
@@ -613,7 +613,8 @@
         aid   (:db/aid props)
         _     (or (not (:validate-data? (opts store)))
                   (b/valid-data? v vt)
-                  (u/raise "Invalid data, expecting" vt "got" v{:input v}))
+                  (u/raise "Invalid data, expecting " vt " got " v
+                    {:input v}))
         i     (b/indexable e aid v vt)
         ft?   (:db/fulltext props)]
     (if (b/giant? i)

--- a/test/datalevin/test/transact.cljc
+++ b/test/datalevin/test/transact.cljc
@@ -650,19 +650,24 @@
              :code    {:db/valueType :db.type/long}}
         dir (u/tmp-dir (str "skip-" (UUID/randomUUID)))
         db  (d/empty-db dir sc {:validate-data? true})]
-    (is (thrown-with-msg? Exception #"Invalid data, expecting"
+    (is (thrown-with-msg? Exception
+          #"Invalid data, expecting :db.type/uuid got \"ibm\""
           (d/db-with db
             [{:db/id -1 :company "IBM" :id "ibm" :code 1}])))
-    (is (thrown-with-msg? Exception #"Invalid data, expecting"
+    (is (thrown-with-msg? Exception
+          #"Invalid data, expecting :db.type/string got 1"
           (d/db-with db
             [{:db/id -2 :company 1 :id (random-uuid) :code 1}])))
-    (is (thrown-with-msg? Exception #"Invalid data, expecting"
+    (is (thrown-with-msg? Exception
+          #"Invalid data, expecting :db.type/string got :abc"
           (d/db-with db
             [{:db/id -3 :company :abc :id (random-uuid) :code 1}])))
-    (is (thrown-with-msg? Exception #"Invalid data, expecting"
+    (is (thrown-with-msg? Exception
+          #"Invalid data, expecting :db.type/string got 1.0"
           (d/db-with db
             [{:db/id -4 :company 1.0 :id (random-uuid) :code 1}])))
-    (is (thrown-with-msg? Exception #"Invalid data, expecting"
+    (is (thrown-with-msg? Exception
+          #"Invalid data, expecting :db.type/long got \"1\""
           (d/db-with db
             [{:db/id -5 :company "XYZ" :id (random-uuid) :code "1"}])))
     (d/close-db db)


### PR DESCRIPTION
When using 0.8.26 there were some spacing issues with the invalid data error messages. 

```
Execution error (ExceptionInfo) at datalevin.storage/insert-data (storage.cljc:616).
Invalid data, expecting:db.type/longgot"foo"
```

This PR fixes the spacing.

```
Execution error (ExceptionInfo) at datalevin.storage/insert-data (storage.cljc:616).
Invalid data, expecting :db.type/long got "foo"
```

I also found some inconsistencies with the Invalid data error messages in other parts of the codebase. So updated those too.

Let me know if I need to make any changes.