### PR TITLE
fix optimization regression and redundant call

### DIFF
--- a/src/datalevin/db.clj
+++ b/src/datalevin/db.clj
@@ -960,9 +960,6 @@
         (nil? entity)
         (recur entities new-es)
 
-        (@de-entity? entity)
-        (recur (concatv entities (reverse (@de-entity->txs entity))) new-es)
-
         (map? entity)
         (recur entities (conj! new-es (assoc entity :db/updated-at tx-time)))
 
@@ -1044,7 +1041,7 @@
 
              (@de-entity? entity)
              (recur report
-                    (concatv entities (reverse (@de-entity->txs entity))))
+                    (concatv entities (@de-entity->txs entity)))
 
 
              :let [^DB db      (:db-after report)


### PR DESCRIPTION
`reverse` was needed as entities was a list. Now that the collection is a vector, reverse is not needed. fixes https://github.com/juji-io/datalevin/issues/244