### PR TITLE
Use FreeBSD package manager provided liblmdb.

### DIFF
--- a/src/datalevin/binding/java.clj
+++ b/src/datalevin/binding/java.clj
@@ -1176,4 +1176,14 @@
         (u/raise "Failed to extract LMDB library: " e
                  {:resource resource :path fpath})))))
 
-(extract-lmdb)
+(defn use-os-package []
+  (let [fpath "/usr/local/lib/liblmdb.so"]
+    (if (.exists  (File. fpath))
+      (System/setProperty "lmdbjava.native.lib" fpath)
+      (u/raise (str "liblmdb.so not found at " fpath
+                    ", have you installed the package?")))))
+
+(if (s/starts-with? (s/lower-case (System/getProperty "os.name")) "freebsd")
+  (use-os-package)
+  (extract-lmdb))
+


### PR DESCRIPTION
Hi,

datalevin 0.9 throws "Unsupported OS FreeBSD" on FreeBSD.

FreeBSD provides a package and a port for lmdb, currently at version 0.9.32.1
see https://www.freshports.org/databases/lmdb/.

This patch checks whether the file liblmdb.so exists in the canonical location and points the system property "lmdbjava.native.lib" at it.  If the file does not exist it throws with a reminder to install the package.

I added the function `use-os-package` instead of adding it to the platform detection in `extract-lmdb` because it would make the function name `extract-lmdb` misleading.

Running `lein test`, all tests pass on FreeBSD 14.0 amd64.