### PR TITLE
Fix for 288

### DIFF
--- a/src/datalevin/parser.clj
+++ b/src/datalevin/parser.clj
@@ -440,8 +440,8 @@
 ;; and-clause      = [ 'and' clause+ ]
 
 (deftrecord Pattern   [source pattern])
-(deftrecord Predicate [fn args])
-(deftrecord Function  [fn args binding])
+(deftrecord Predicate [fn args fn-object])
+(deftrecord Function  [fn args binding fn-object])
 (deftrecord RuleExpr  [source name args]) ;; TODO rule with constant or '_' as argument
 (deftrecord Not       [source vars clauses])
 (deftrecord Or        [source rule-vars clauses])
@@ -477,10 +477,20 @@
       (when (and fn* args*)
         [fn* args*]))))
 
+(defn resolve-fn-symbol-for-caching
+  "Using function symbol alone does not detect changes to the function.
+  This can lead to the cache returning a stale result. By storing the resolved
+  function object the cache can be invalidated correctly when the function
+  implementation changes. This is only done for qualified functions."
+  [fn*]
+  (let [sym (-> fn* :symbol)]
+    (when (qualified-symbol? sym)
+      @(resolve sym))))
+
 (defn parse-pred [form]
   (when (of-size? form 1)
     (when-let [[fn* args*] (parse-call (first form))]
-      (-> (Predicate. fn* args*)
+      (-> (Predicate. fn* args* (resolve-fn-symbol-for-caching fn*))
           (with-source form)))))
 
 (defn parse-fn [form]
@@ -488,7 +498,7 @@
     (let [[call binding] form]
       (when-let [[fn* args*] (parse-call call)]
         (when-let [binding* (parse-binding binding)]
-          (-> (Function. fn* args* binding*)
+          (-> (Function. fn* args* binding* (resolve-fn-symbol-for-caching fn*))
               (with-source form)))))))
 
 (defn parse-rule-expr [form]

--- a/src/datalevin/parser.clj
+++ b/src/datalevin/parser.clj
@@ -479,9 +479,10 @@
 
 (defn resolve-fn-symbol-for-caching
   "Using function symbol alone does not detect changes to the function.
-  This can lead to the cache returning a stale result. By storing the resolved
-  function object the cache can be invalidated correctly when the function
-  implementation changes. This is only done for qualified functions."
+  This can lead to the cache returning a stale result. By storing the
+  resolved function object the cache can be invalidated correctly when
+  the function implementation changes. This is only done for qualified
+  functions."
   [fn*]
   (let [sym (-> fn* :symbol)]
     (when (qualified-symbol? sym)

--- a/src/datalevin/query.clj
+++ b/src/datalevin/query.clj
@@ -2304,13 +2304,6 @@
                            e)) plan)
                :late-clauses late-clauses)))))
 
-(defn- parsed-q
-  [q]
-  (or (.get ^LRUCache *query-cache* q)
-      (let [res (dp/parse-query q)]
-        (.put ^LRUCache *query-cache* q res)
-        res)))
-
 (defn- order-comp
   [tg idx di]
   (if (identical? di :asc)
@@ -2389,7 +2382,7 @@
 
 (defn q
   [q & inputs]
-  (let [parsed-q (parsed-q q)
+  (let [parsed-q (dp/parse-query q) 
         result   (q-result parsed-q inputs)]
     (if (instance? FindRel (:qfind parsed-q))
       (let [limit  (:qlimit parsed-q)
@@ -2401,7 +2394,7 @@
 
 (defn- plan-only
   [q & inputs]
-  (let [parsed-q (parsed-q q)]
+  (let [parsed-q (dp/parse-query q)]
     (binding [timeout/*deadline* (timeout/to-deadline (:qtimeout parsed-q))]
       (let [[parsed-q inputs] (plugin-inputs parsed-q inputs)]
         (-> (Context. parsed-q [] {} {} [] nil nil nil (volatile! {})

--- a/test/datalevin/query_test.clj
+++ b/test/datalevin/query_test.clj
@@ -940,11 +940,8 @@
     (d/transact! conn data)
     (is (= (d/q q1 (d/db conn))
            [["Alexander Godunov"] ["Arnold Schwarzenegger"]]))
-    ;; Change the function (can't be done in a redef) so
-    ;; we need to use alter-var-root
-    (alter-var-root #'datalevin.query-test/big-name?
-                    (constantly (fn [x] (> (count x) 20))))
-    (is (= (d/q q1 (d/db conn))
-           [["Arnold Schwarzenegger"]]))
+    (with-redefs [big-name? (fn [x] (> (count x) 20))]
+      (is (= (d/q q1 (d/db conn))
+           [["Arnold Schwarzenegger"]])))
     (d/close conn)
     (u/delete-files dir)))

--- a/test/datalevin/query_test.clj
+++ b/test/datalevin/query_test.clj
@@ -922,3 +922,29 @@
     (is (= (d/q q3 (d/db conn)) [["Alan Rickman"]]))
     (d/close conn)
     (u/delete-files dir)))
+
+(deftest test-issue-288-cache-after-resolving-function-references
+  ;; function needs to be qualified
+  #_{:clj-kondo/ignore [:inline-def]}
+  (defn big-name? [x] (> (count x) 16))
+  (let [dir    (u/tmp-dir (str "limit-offset-" (UUID/randomUUID)))
+        schema (i/load-edn "test/data/movie-schema.edn")
+        data   (i/load-edn "test/data/movie-data.edn")
+        conn   (d/get-conn dir schema)
+        q1     '[:find ?name
+                 :where
+                 [?e :person/name ?name]
+                 [(datalevin.query-test/big-name? ?name)]
+                 :order-by ?name
+                 :limit 2]]
+    (d/transact! conn data)
+    (is (= (d/q q1 (d/db conn))
+           [["Alexander Godunov"] ["Arnold Schwarzenegger"]]))
+    ;; Change the function (can't be done in a redef) so
+    ;; we need to use alter-var-root
+    (alter-var-root #'datalevin.query-test/big-name?
+                    (constantly (fn [x] (> (count x) 20))))
+    (is (= (d/q q1 (d/db conn))
+           [["Arnold Schwarzenegger"]]))
+    (d/close conn)
+    (u/delete-files dir)))

--- a/test/datalevin/test/parser_where.clj
+++ b/test/datalevin/test/parser_where.clj
@@ -45,16 +45,16 @@
   (are [clause res] (= (dp/parse-clause clause) res)
     '[(fn ?a 1) ?x]
     (dp/->Function (dp/->PlainSymbol 'fn) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/->BindScalar (dp/->Variable '?x))
-                   (dp/resolve-fn-symbol-for-caching 'pred))
+                   (dp/resolve-fn-symbol-for-caching 'fn))
 
     '[(fn) ?x]
-    (dp/->Function (dp/->PlainSymbol 'fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'pred))
+    (dp/->Function (dp/->PlainSymbol 'fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'fn))
 
     '[(?custom-fn) ?x]
-    (dp/->Function (dp/->Variable '?custom-fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'pred))
+    (dp/->Function (dp/->Variable '?custom-fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'fn))
 
     '[(?custom-fn ?arg) ?x]
-    (dp/->Function (dp/->Variable '?custom-fn) [(dp/->Variable '?arg)] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'pred))))
+    (dp/->Function (dp/->Variable '?custom-fn) [(dp/->Variable '?arg)] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'fn))))
 
 (deftest rule-expr
   (are [clause res] (= (dp/parse-clause clause) res)

--- a/test/datalevin/test/parser_where.clj
+++ b/test/datalevin/test/parser_where.clj
@@ -31,28 +31,30 @@
 (deftest test-pred
   (are [clause res] (= (dp/parse-clause clause) res)
     '[(pred ?a 1)]
-    (dp/->Predicate (dp/->PlainSymbol 'pred) [(dp/->Variable '?a) (dp/->Constant 1)])
+    (dp/->Predicate (dp/->PlainSymbol 'pred) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/resolve-fn-symbol-for-caching 'pred))
 
     '[(pred)]
-    (dp/->Predicate (dp/->PlainSymbol 'pred) [])
+    (dp/->Predicate (dp/->PlainSymbol 'pred) []
+                    (dp/resolve-fn-symbol-for-caching 'pred))
 
     '[(?custom-pred ?a)]
-    (dp/->Predicate (dp/->Variable '?custom-pred) [(dp/->Variable '?a)])
-    ))
+    (dp/->Predicate (dp/->Variable '?custom-pred) [(dp/->Variable '?a)]
+                    (dp/resolve-fn-symbol-for-caching 'pred))))
 
 (deftest test-fn
   (are [clause res] (= (dp/parse-clause clause) res)
     '[(fn ?a 1) ?x]
-    (dp/->Function (dp/->PlainSymbol 'fn) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/->BindScalar (dp/->Variable '?x)))
+    (dp/->Function (dp/->PlainSymbol 'fn) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/->BindScalar (dp/->Variable '?x))
+                   (dp/resolve-fn-symbol-for-caching 'pred))
 
     '[(fn) ?x]
-    (dp/->Function (dp/->PlainSymbol 'fn) [] (dp/->BindScalar (dp/->Variable '?x)))
+    (dp/->Function (dp/->PlainSymbol 'fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'pred))
 
     '[(?custom-fn) ?x]
-    (dp/->Function (dp/->Variable '?custom-fn) [] (dp/->BindScalar (dp/->Variable '?x)))
+    (dp/->Function (dp/->Variable '?custom-fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'pred))
 
     '[(?custom-fn ?arg) ?x]
-    (dp/->Function (dp/->Variable '?custom-fn) [(dp/->Variable '?arg)] (dp/->BindScalar (dp/->Variable '?x)))))
+    (dp/->Function (dp/->Variable '?custom-fn) [(dp/->Variable '?arg)] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'pred))))
 
 (deftest rule-expr
   (are [clause res] (= (dp/parse-clause clause) res)


### PR DESCRIPTION
This is the start of a fix for #288. However, it seems there are two levels of caching. The query results are cached and parsing the query is also cached. Why my test still currently fails.

I've fixed the first level of caching (the result caching) by adding a fn-object to the key. However, the query caching will be more challenging to fix as we need to parse the query to resolve the functions, and if we're parsing the query then there's not much point caching parsing the query.

One solution would be remove the query caching completely (but keep the fix for result caching):

```
(defn- parsed-q
  [q]
  (or (.get ^LRUCache *query-cache* q)
      (let [res (dp/parse-query q)]
        (.put ^LRUCache *query-cache* q res)
        res)))
```

Would become:

```
(defn- parsed-q
  [q]
  (dp/parse-query q))
```

However, thinking about the problem some more. This bug only really comes up when working at the repl and or in contexts where a function gets rebound.

Depending on how critical the current elegant query caching is. It might be simpler to just document invalidating the cache manually when changing a function used in a query.

Thoughts?