### PR TITLE
Add query caching back #288 #289

### DIFF
--- a/test/datalevin/test/parser_where.clj
+++ b/test/datalevin/test/parser_where.clj
@@ -31,30 +31,27 @@
 (deftest test-pred
   (are [clause res] (= (dp/parse-clause clause) res)
     '[(pred ?a 1)]
-    (dp/->Predicate (dp/->PlainSymbol 'pred) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/resolve-fn-symbol-for-caching 'pred))
+    (dp/->Predicate (dp/->PlainSymbol 'pred) [(dp/->Variable '?a) (dp/->Constant 1)])
 
     '[(pred)]
-    (dp/->Predicate (dp/->PlainSymbol 'pred) []
-                    (dp/resolve-fn-symbol-for-caching 'pred))
+    (dp/->Predicate (dp/->PlainSymbol 'pred) [])
 
     '[(?custom-pred ?a)]
-    (dp/->Predicate (dp/->Variable '?custom-pred) [(dp/->Variable '?a)]
-                    (dp/resolve-fn-symbol-for-caching 'pred))))
+    (dp/->Predicate (dp/->Variable '?custom-pred) [(dp/->Variable '?a)])))
 
 (deftest test-fn
   (are [clause res] (= (dp/parse-clause clause) res)
     '[(fn ?a 1) ?x]
-    (dp/->Function (dp/->PlainSymbol 'fn) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/->BindScalar (dp/->Variable '?x))
-                   (dp/resolve-fn-symbol-for-caching 'fn))
+    (dp/->Function (dp/->PlainSymbol 'fn) [(dp/->Variable '?a) (dp/->Constant 1)] (dp/->BindScalar (dp/->Variable '?x)))
 
     '[(fn) ?x]
-    (dp/->Function (dp/->PlainSymbol 'fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'fn))
+    (dp/->Function (dp/->PlainSymbol 'fn) [] (dp/->BindScalar (dp/->Variable '?x)))
 
     '[(?custom-fn) ?x]
-    (dp/->Function (dp/->Variable '?custom-fn) [] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'fn))
+    (dp/->Function (dp/->Variable '?custom-fn) [] (dp/->BindScalar (dp/->Variable '?x)))
 
     '[(?custom-fn ?arg) ?x]
-    (dp/->Function (dp/->Variable '?custom-fn) [(dp/->Variable '?arg)] (dp/->BindScalar (dp/->Variable '?x)) (dp/resolve-fn-symbol-for-caching 'fn))))
+    (dp/->Function (dp/->Variable '?custom-fn) [(dp/->Variable '?arg)] (dp/->BindScalar (dp/->Variable '?x)))))
 
 (deftest rule-expr
   (are [clause res] (= (dp/parse-clause clause) res)


### PR DESCRIPTION
As mentioned [here](
https://github.com/juji-io/datalevin/pull/289#issuecomment-2434447388) I realised there was a simple way to keep the query cache and prevent function implementation changes from returning stale results from the result cache.

It looks like currently this is only needed for functions in `:where` clause as functions in `:find` clause don't seem to have the same problem. However, they might in future so I've extended the test to catch potential future regressions where `:find` function implementation changes cause stale results.

Apologies for not seeing this solution the first time round.

EDIT: Forgot to mention micro benchmarking (usual benchmarking caveats). From what I could see the query parsing cache definitely makes a difference. As you said compared to results cache it's much less impactful . But it does add up when there's a lot of repeat queries and the queries are big. Reminds me of Honesql, adding query parsing cache made a noticeable difference in my experience, especially with really gnarly SQL queries. 