### PR TITLE
Docs: JVM 8 -> 11

### DIFF
--- a/doc/limits.md
+++ b/doc/limits.md
@@ -21,6 +21,6 @@
 * The total data size of a Datalevin database has the same limit as LMDB's, e.g.
   128TB on a modern 64-bit machine that implements 48-bit address spaces.
 
-* Currently supports Clojure on JVM 8 or the above, but adding support for other
-  Clojure-hosting runtime is possible, since bindings for LMDB
-  exist in almost all major languages and available on most platforms.
+* Currently supports Clojure on JVM 11 or above, but adding support for other
+  Clojure-hosting runtimes is possible, since bindings for LMDB
+  exist in almost all major languages and are available on most platforms.


### PR DESCRIPTION
Latest release bumps minimum JVM to 11.