### PR TITLE
Fix using datalevin from Git SHA

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,4 +42,6 @@
                   :jvm-opts    ["--add-opens=java.base/java.nio=ALL-UNNAMED"
                                 "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
                                 "-Dclojure.compiler.direct-linking=true"]
-                  }}}
+                  }
+           :build   {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}}
+                     :ns-default build}}}


### PR DESCRIPTION
This [commit](https://github.com/juji-io/datalevin/commit/6365db86410237bbfc3de4da9fbc6673216c1510) removed the `build` alias which broke `:deps/prep-lib` and using datalevin from the git sha