### PR TITLE
Vector database feedback

### DIFF
--- a/doc/vector.md
+++ b/doc/vector.md
@@ -177,7 +177,7 @@ queries. This function takes the DB, the query vector and an optional option map
     (set (d/q '[:find [?i ...]
                 :in $ ?q
                 :where
-                [(vec-neighbors $ :?q {:top 4 :domains ["embedding"]}) [[?e _ _]]]
+                [(vec-neighbors $ ?q {:top 4 :domains ["embedding"]}) [[?e _ _]]]
                 [?e :id ?i]]
            (d/db conn) (data "cat"))))
 ;;=>  #{"cat" "jaguar" "animal" "rooster"}


### PR DESCRIPTION
Hello

I've been testing the vector features for the last few days and I have some feedback that may or may not be useful.

Feel free to ignore if it's no longer relevant :^)

Thank you for the great work! 🚀

---

**No index is created if the vector attribute is namespaced**

`io.github.juji-io/datalevin {:git/sha "9a14b5992acae4f2bbdc741ea23c9213be4328be"}`

I tried to use `:kudos.chunk/content_markdown-embedding` as a vector attribute, but when I did no vector index was created. Changing to `:content_markdown-embedding` resulted in the index being created as expected.

**Some queries stall and cause heap exhaustion**

`io.github.juji-io/datalevin {:git/sha "9a14b5992acae4f2bbdc741ea23c9213be4328be"}`

```
(comment
  ;; This query is instant:
  (time (d/q '[:find [?md]
               :in $ ?emb-q
               :where
               [(vec-neighbors $ :content_markdown-embedding ?emb-q) [[?e _ ?v]]]
               [?e :kudos.chunk/content_markdown ?md]]
             (d/db conn)
             (-> sample first :content_markdown-embedding)))

  ;; This query causes heap exhaustion:
  (time (d/q '[:find [?md ?emb]
               :in $ ?emb-q
               :where
               [(vec-neighbors $ :content_markdown-embedding ?emb-q) [[?e _ ?v]]]
               [?e :kudos.chunk/content_markdown ?md]
               [?e :content_markdown-embedding ?emb]]
             (d/db conn)
             (-> sample first :content_markdown-embedding)))

  ;; This query causes heap exhaustion:
  (time (d/q '[:find [?emb]
               :in $ ?emb-q
               :where
               [(vec-neighbors $ :content_markdown-embedding ?emb-q) [[?e _ ?v]]]
               [?e :content_markdown-embedding ?emb]]
             (d/db conn)
             (-> sample first :content_markdown-embedding)))

  ;; This query is instant:
  (time (d/q '[:find (pull ?e [*])
               :in $ ?emb-q
               :where
               [(vec-neighbors $ :content_markdown-embedding ?emb-q) [[?e]]]]
             (d/db conn)
             (-> sample first :content_markdown-embedding)))

  ;; This query is instant:
  (time (d/q '[:find (pull ?e [*])
               :in $ ?emb-q
               :where
               [?e :content_markdown-embedding ?emb-q]]
             (d/db conn)
             (-> sample first :content_markdown-embedding)))

  ;; This query is instant:
  (time (d/q '[:find [?md]
               :in $ ?emb-q
               :where
               [?e :kudos.chunk/content_markdown ?md]
               [?e :content_markdown-embedding ?emb-q]]
             (d/db conn)
             (-> sample first :content_markdown-embedding)))

  ;; This query causes heap exhaustion:
  (time (d/q '[:find [?emb]
               :in $ ?emb-q
               :where
               [?e :content_markdown-embedding ?emb]
               [(vec-neighbors $ :content_markdown-embedding ?emb-q) [[?e _ ?v]]]]
             (d/db conn)
             (-> sample first :content_markdown-embedding))))
```