### PR TITLE
Swap Nippy for hako (exploratory)

### DIFF
--- a/benchmarks/alloc_read_profile.clj
+++ b/benchmarks/alloc_read_profile.clj
@@ -1,0 +1,76 @@
+(ns alloc-read-profile
+  "Fine-grained alloc profile for Datalevin read paths. Break down where
+  the ~8 KB/op range-scan allocation goes.
+
+  Run: clj -M:bench -m alloc-read-profile"
+  (:require [datalevin.core :as d]
+            [datalevin.bits :as b])
+  (:import (com.sun.management ThreadMXBean)
+           (java.lang.management ManagementFactory)))
+
+(defn- ^ThreadMXBean tmx []
+  (ManagementFactory/getThreadMXBean))
+
+(defn- allocated-bytes ^long [^ThreadMXBean b]
+  (.getThreadAllocatedBytes b (.getId (Thread/currentThread))))
+
+(defn- profile [label f warmup n]
+  (dotimes [_ warmup] (f))
+  (System/gc)
+  (let [b (tmx)
+        start (allocated-bytes b)
+        _ (dotimes [_ n] (f))
+        end (allocated-bytes b)
+        per-op (/ (double (- end start)) n)]
+    (println (format "  %-40s %10.1f B/op" label per-op))
+    per-op))
+
+(defn- fresh-conn []
+  (let [dir (str "/tmp/dtlv-alloc-read-" (System/currentTimeMillis) "-" (rand-int 100000))]
+    (d/get-conn dir
+                {:name {:db/valueType :db.type/string}
+                 :age  {:db/valueType :db.type/long}}
+                {:kv-opts {:flags #{:nosync}}})))
+
+(defn- gen-people [n]
+  (vec (for [i (range n)]
+         {:db/id (- (inc i)) :name (str "p-" i) :age (+ 18 (mod i 50))})))
+
+(defn -main [& _]
+  (println "=== Datalevin read-path alloc profile ===\n")
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (try
+      (println "-- baseline --")
+      (profile "empty fn" (fn [] nil) 1000 100000)
+      (profile "db deref"     (fn [] @conn) 1000 100000)
+
+      (println "\n-- query variants --")
+      (profile "q :find ?e"
+               (fn [] (d/q '[:find ?e :where [?e :name]] @conn)) 100 10000)
+      (profile "q :find ?e ?n"
+               (fn [] (d/q '[:find ?e ?n :where [?e :name ?n]] @conn)) 100 10000)
+      (profile "q :find ?n"
+               (fn [] (d/q '[:find ?n :where [?e :name ?n]] @conn)) 100 10000)
+
+      (println "\n-- entity paths --")
+      (profile "d/entity"
+               (fn [] (d/entity @conn 50)) 100 10000)
+      (profile "d/entity + touch"
+               (fn [] (d/touch (d/entity @conn 50))) 100 10000)
+      (profile "d/entity + touch + into map"
+               (fn [] (into {} (d/touch (d/entity @conn 50)))) 100 10000)
+
+      (println "\n-- direct datom access --")
+      (profile "-datoms :eav (100)"
+               (fn []
+                 (let [ds (into [] (datalevin.db/-datoms @conn :eav nil nil nil))]
+                   (count ds)))
+               100 1000)
+
+      (println "\n-- codec-only micro (b/deserialize) --")
+      (let [encoded (b/serialize {:name "Alice" :age 30})]
+        (profile "b/deserialize small map"
+                 (fn [] (b/deserialize encoded)) 1000 100000))
+
+      (finally (d/close conn)))))

--- a/benchmarks/datom_alloc.clj
+++ b/benchmarks/datom_alloc.clj
@@ -1,0 +1,60 @@
+(ns datom-alloc
+  "Per-op alloc for datom-shaped payloads: hako vs nippy.
+  Includes reused-Reader hako path for a fair comparison to
+  nippy's fast-thaw (which reuses internal state)."
+  (:require [datalevin.datom :as d]
+            [s-exp.hako :as hako]
+            [taoensso.nippy :as nippy])
+  (:import (com.s_exp.hako Reader Writer)
+           (com.sun.management ThreadMXBean)
+           (java.lang.foreign MemorySegment ValueLayout)
+           (java.lang.management ManagementFactory)))
+
+(def payloads
+  {:datom-small     (d/datom 1 :name "Alice" 100 true)
+   :datom-batch-100 (vec (for [i (range 100)]
+                           (d/datom i (rand-nth [:name :email :age :status :owner])
+                                    (if (odd? i) (str "v-" i) i)
+                                    (+ 1000 i) (even? i))))
+   :datom-batch-1k  (vec (for [i (range 1000)]
+                           (d/datom i (rand-nth [:name :email :age :status :owner])
+                                    (if (odd? i) (str "v-" i) i)
+                                    (+ 1000 i) (even? i))))})
+
+(defn- ^ThreadMXBean tmx []
+  (ManagementFactory/getThreadMXBean))
+
+(defn- allocated-bytes ^long [^ThreadMXBean b]
+  (.getThreadAllocatedBytes b (.getId (Thread/currentThread))))
+
+(defn- alloc-per-op [f iters]
+  (dotimes [_ 5000] (f))
+  (System/gc)
+  (let [b (tmx)
+        start (allocated-bytes b)
+        _ (dotimes [_ iters] (f))
+        end (allocated-bytes b)]
+    (/ (double (- end start)) iters)))
+
+(defn -main [& _]
+  (let [wr ^Writer (hako/writer 65536)
+        rd ^Reader (hako/reader (byte-array 8))
+        iters 50000]
+    (println (format "%-20s %-24s %12s"
+                     "payload" "op" "B/op"))
+    (println (apply str (repeat 60 "-")))
+    (doseq [[label v] payloads]
+      (let [h-enc (hako/encode v)
+            n-enc (nippy/fast-freeze v)
+            nn-enc (nippy/freeze v)]
+        (println (format "%-20s %-24s %12.0f" (name label) "hako encode-into!"
+                         (alloc-per-op #(hako/encode-into! wr v) iters)))
+        (println (format "%-20s %-24s %12.0f" (name label) "nippy fast-freeze"
+                         (alloc-per-op #(nippy/fast-freeze v) iters)))
+        (println (format "%-20s %-24s %12.0f" (name label) "hako decode (fresh Rd)"
+                         (alloc-per-op #(hako/decode h-enc {:cache-idents true}) iters)))
+        (println (format "%-20s %-24s %12.0f" (name label) "hako decode-into! (reused)"
+                         (alloc-per-op #(hako/decode-into! rd h-enc {:cache-idents true}) iters)))
+        (println (format "%-20s %-24s %12.0f" (name label) "nippy fast-thaw"
+                         (alloc-per-op #(nippy/fast-thaw n-enc) iters)))
+        (println)))))

--- a/benchmarks/e2e_alloc.clj
+++ b/benchmarks/e2e_alloc.clj
@@ -1,0 +1,90 @@
+(ns e2e-alloc
+  "Per-op allocation profile for Datalevin workloads.
+  Measures bytes allocated via ThreadMXBean.getThreadAllocatedBytes
+  over a warmed loop. Run same script on master + hako-codec, diff.
+
+  Run: clj -M:bench -m e2e-alloc"
+  (:require [datalevin.core :as d])
+  (:import (com.sun.management ThreadMXBean)
+           (java.lang.management ManagementFactory)))
+
+(defn- ^ThreadMXBean tmx []
+  (ManagementFactory/getThreadMXBean))
+
+(defn- allocated-bytes ^long [^ThreadMXBean b]
+  (.getThreadAllocatedBytes b (.getId (Thread/currentThread))))
+
+(defn- fresh-conn []
+  (let [dir (str "/tmp/dtlv-alloc-" (System/currentTimeMillis) "-" (rand-int 100000))]
+    (d/get-conn dir
+                {:name    {:db/valueType :db.type/string}
+                 :email   {:db/valueType :db.type/string}
+                 :age     {:db/valueType :db.type/long}
+                 :active? {:db/valueType :db.type/boolean}
+                 :owner   {:db/valueType :db.type/ref}
+                 :tags    {:db/valueType :db.type/keyword
+                           :db/cardinality :db.cardinality/many}})))
+
+(defn- gen-people [n]
+  (vec (for [i (range n)]
+         {:db/id (- (inc i))
+          :name (str "person-" i)
+          :email (str "p" i "@example.com")
+          :age (+ 18 (mod i 50))
+          :active? (odd? i)
+          :tags [(keyword (str "tag-" (mod i 10)))
+                 (keyword (str "cat-" (mod i 5)))]})))
+
+(defn- profile
+  "Warm, then measure alloc delta over N iterations. Returns bytes/op."
+  [label f warmup n]
+  (dotimes [_ warmup] (f))
+  (System/gc)
+  (let [b (tmx)
+        start (allocated-bytes b)
+        _ (dotimes [_ n] (f))
+        end (allocated-bytes b)
+        total (- end start)
+        per-op (/ (double total) n)]
+    (println (format "  %-30s %12.0f B/op  (%d ops)" label per-op n))
+    per-op))
+
+(defn -main [& _]
+  (println "=== Datalevin per-op allocation profile ===\n")
+
+  (println "--- batch transact (100 people) ---")
+  (profile "batch transact"
+           (fn []
+             (let [conn (fresh-conn)]
+               (try (d/transact! conn (gen-people 100))
+                    (finally (d/close conn)))))
+           5 50)
+
+  (println "\n--- range scan (100 people, :name query) ---")
+  (let [conn (fresh-conn)
+        _ (d/transact! conn (gen-people 100))]
+    (try
+      (profile "range scan"
+               (fn [] (d/q '[:find ?e ?n :where [?e :name ?n]] @conn))
+               100 10000)
+      (finally (d/close conn))))
+
+  (println "\n--- entity pull ---")
+  (let [conn (fresh-conn)
+        _ (d/transact! conn (gen-people 100))]
+    (try
+      (profile "entity pull"
+               (fn [] (into {} (d/touch (d/entity @conn 50))))
+               100 10000)
+      (finally (d/close conn))))
+
+  (println "\n--- full round-trip (transact + read 100) ---")
+  (profile "roundtrip"
+           (fn []
+             (let [conn (fresh-conn)]
+               (try
+                 (d/transact! conn (gen-people 100))
+                 (d/q '[:find ?e ?n ?a
+                        :where [?e :name ?n] [?e :age ?a]] @conn)
+                 (finally (d/close conn)))))
+           5 50))

--- a/benchmarks/e2e_hako_vs_master.clj
+++ b/benchmarks/e2e_hako_vs_master.clj
@@ -1,0 +1,72 @@
+(ns e2e-hako-vs-master
+  "End-to-end Datalevin bench for the hako branch.
+
+  Measure realistic workloads: batch transact, range scan, entity pull.
+  Run twice — once on this branch (hako), once on master (nippy) —
+  and diff the numbers.
+
+  Run: clj -M:bench -m e2e-hako-vs-master"
+  (:require [criterium.core :as c]
+            [datalevin.core :as d]))
+
+(defn- fresh-conn []
+  (let [dir (str "/tmp/dtlv-bench-" (System/currentTimeMillis) "-" (rand-int 100000))]
+    (d/get-conn dir
+                {:name    {:db/valueType :db.type/string}
+                 :email   {:db/valueType :db.type/string}
+                 :age     {:db/valueType :db.type/long}
+                 :active? {:db/valueType :db.type/boolean}
+                 :owner   {:db/valueType :db.type/ref}
+                 :tags    {:db/valueType :db.type/keyword
+                           :db/cardinality :db.cardinality/many}})))
+
+(defn- gen-people [n]
+  (vec (for [i (range n)]
+         {:db/id (- (inc i))
+          :name (str "person-" i)
+          :email (str "p" i "@example.com")
+          :age (+ 18 (mod i 50))
+          :active? (odd? i)
+          :tags [(keyword (str "tag-" (mod i 10)))
+                 (keyword (str "cat-" (mod i 5)))]})))
+
+(defn -main [& _]
+  (println "=== e2e Datalevin bench ===")
+  (println "hako branch — measure vs master baseline separately.\n")
+
+  ;; Warm the LMDB layer.
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (d/close conn))
+
+  (println "--- batch transact (100 people, schema-typed) ---")
+  (c/quick-bench
+   (let [conn (fresh-conn)]
+     (try
+       (d/transact! conn (gen-people 100))
+       (finally (d/close conn)))))
+
+  (println "\n--- range scan (100 people, :find ?e ?n :where [?e :name ?n]) ---")
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (try
+      (c/quick-bench
+       (d/q '[:find ?e ?n :where [?e :name ?n]] @conn))
+      (finally (d/close conn))))
+
+  (println "\n--- entity pull (single :name lookup + touch) ---")
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (try
+      (c/quick-bench
+       (into {} (d/touch (d/entity @conn 50))))
+      (finally (d/close conn))))
+
+  (println "\n--- transact then read: full round-trip (100 people) ---")
+  (c/quick-bench
+   (let [conn (fresh-conn)]
+     (try
+       (d/transact! conn (gen-people 100))
+       (d/q '[:find ?e ?n ?a
+              :where [?e :name ?n] [?e :age ?a]] @conn)
+       (finally (d/close conn))))))

--- a/benchmarks/e2e_nosync.clj
+++ b/benchmarks/e2e_nosync.clj
@@ -1,0 +1,69 @@
+(ns e2e-nosync
+  "End-to-end Datalevin bench with LMDB :nosync mode.
+  Removes fsync overhead so codec share of latency is visible.
+
+  Run: clj -M:bench -m e2e-nosync"
+  (:require [criterium.core :as c]
+            [datalevin.core :as d]))
+
+(defn- fresh-conn []
+  (let [dir (str "/tmp/dtlv-nosync-" (System/currentTimeMillis) "-" (rand-int 100000))]
+    (d/get-conn dir
+                {:name    {:db/valueType :db.type/string}
+                 :email   {:db/valueType :db.type/string}
+                 :age     {:db/valueType :db.type/long}
+                 :active? {:db/valueType :db.type/boolean}
+                 :owner   {:db/valueType :db.type/ref}
+                 :tags    {:db/valueType :db.type/keyword
+                           :db/cardinality :db.cardinality/many}}
+                {:kv-opts {:flags #{:nosync}}})))
+
+(defn- gen-people [n]
+  (vec (for [i (range n)]
+         {:db/id (- (inc i))
+          :name (str "person-" i)
+          :email (str "p" i "@example.com")
+          :age (+ 18 (mod i 50))
+          :active? (odd? i)
+          :tags [(keyword (str "tag-" (mod i 10)))
+                 (keyword (str "cat-" (mod i 5)))]})))
+
+(defn -main [& _]
+  (println "=== e2e Datalevin bench (LMDB :nosync) ===\n")
+
+  ;; Warm
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (d/close conn))
+
+  (println "--- batch transact (100 people) ---")
+  (c/quick-bench
+   (let [conn (fresh-conn)]
+     (try
+       (d/transact! conn (gen-people 100))
+       (finally (d/close conn)))))
+
+  (println "\n--- range scan (100 people) ---")
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (try
+      (c/quick-bench
+       (d/q '[:find ?e ?n :where [?e :name ?n]] @conn))
+      (finally (d/close conn))))
+
+  (println "\n--- entity pull ---")
+  (let [conn (fresh-conn)]
+    (d/transact! conn (gen-people 100))
+    (try
+      (c/quick-bench
+       (into {} (d/touch (d/entity @conn 50))))
+      (finally (d/close conn))))
+
+  (println "\n--- transact + read roundtrip (100) ---")
+  (c/quick-bench
+   (let [conn (fresh-conn)]
+     (try
+       (d/transact! conn (gen-people 100))
+       (d/q '[:find ?e ?n ?a
+              :where [?e :name ?n] [?e :age ?a]] @conn)
+       (finally (d/close conn))))))

--- a/benchmarks/hako_vs_nippy.clj
+++ b/benchmarks/hako_vs_nippy.clj
@@ -1,0 +1,80 @@
+(ns hako-vs-nippy
+  "Measure Datom-serialization delta between hako and nippy on
+  Datalevin-shaped payloads.
+
+  Run: clj -M:bench -m hako-vs-nippy"
+  (:require [criterium.core :as c]
+            [datalevin.datom :as d]
+            [s-exp.hako :as hako]
+            [taoensso.nippy :as nippy])
+  (:import (com.s_exp.hako Writer)
+           (java.lang.foreign MemorySegment ValueLayout)))
+
+(defn- seg->bytes ^bytes [^MemorySegment seg]
+  (let [n (.byteSize seg)
+        arr (byte-array n)]
+    (MemorySegment/copy seg ValueLayout/JAVA_BYTE 0 arr 0 n)
+    arr))
+
+(def payloads
+  {:datom-small     (d/datom 1 :name "Alice" 100 true)
+   :datom-numeric   (d/datom 42 :age 30 100 true)
+   :datom-ref       (d/datom 42 :owner 7 100 true)
+   :datom-batch-10  (vec (for [i (range 10)]
+                           (d/datom i (rand-nth [:name :email :age :status :owner])
+                                    (if (odd? i) (str "v-" i) i)
+                                    (+ 1000 i) (even? i))))
+   :datom-batch-100 (vec (for [i (range 100)]
+                           (d/datom i (rand-nth [:name :email :age :status :owner])
+                                    (if (odd? i) (str "v-" i) i)
+                                    (+ 1000 i) (even? i))))
+   :datom-batch-1k  (vec (for [i (range 1000)]
+                           (d/datom i (rand-nth [:name :email :age :status :owner])
+                                    (if (odd? i) (str "v-" i) i)
+                                    (+ 1000 i) (even? i))))})
+
+(defn -main [& args]
+  (let [selected (if (seq args)
+                   (select-keys payloads (map keyword args))
+                   payloads)
+        wr (hako/writer 65536)
+        rd (hako/reader (byte-array 8))]
+    (doseq [[label payload] selected]
+      (println "===" label "===")
+      (let [hako-enc       (hako/encode payload)
+            nippy-fast-enc (nippy/fast-freeze payload)
+            nippy-enc      (nippy/freeze payload)]
+        (println "  size — hako:" (alength hako-enc)
+                 " nippy-fast:" (alength nippy-fast-enc)
+                 " nippy:" (alength nippy-enc))
+        (println "  hako encode-into! → seg:")
+        (c/quick-bench (hako/encode-into! wr payload))
+        (println "  hako encode → byte[]:")
+        (c/quick-bench (hako/encode payload))
+        (println "  nippy fast-freeze:")
+        (c/quick-bench (nippy/fast-freeze payload))
+        (println "  nippy freeze:")
+        (c/quick-bench (nippy/freeze payload))
+        (println "  hako decode (byte[]):")
+        (c/quick-bench (hako/decode hako-enc {:cache-idents true}))
+        (println "  nippy fast-thaw:")
+        (c/quick-bench (nippy/fast-thaw nippy-fast-enc))
+        (println "  nippy thaw:")
+        (c/quick-bench (nippy/thaw nippy-enc))))
+    (.close wr)))
+
+
+
+;; │ payload          │ hako-seg encode │ nippy-fast encode │ ratio │ hako-seg decode │ nippy-fast decode │ ratio │
+;; ├──────────────────┼─────────────────┼───────────────────┼───────┼─────────────────┼───────────────────┼───────┤
+;; │ single datom     │ 141 ns          │ 218 ns            │ 1.5×  │ 203 ns          │ 222 ns            │ 1.1×  │
+;; │ 100-datom batch  │ 11.3 µs         │ 19.4 µs           │ 1.7×  │ 18.5 µs         │ 29.5 µs           │ 1.6×  │
+;; │ 1000-datom batch │ 103 µs          │ 203 µs            │ 2.0×  │ 136 µs          │ 298 µs            │ 2.2×  │
+
+;; Wire size:
+
+;; │ payload          │ hako    │ nippy-fast │ nippy (Snappy) │ vs nippy-fast │ vs nippy    │
+;; ├──────────────────┼─────────┼────────────┼────────────────┼───────────────┼─────────────┤
+;; │ single datom     │ 37 B    │ 47 B       │ 51 B           │ 21% smaller   │ 27% smaller │
+;; │ 100-datom batch  │ 2574 B  │ 4541 B     │ 4545 B         │ 43% smaller   │ 43% smaller │
+;; │ 1000-datom batch │ 26347 B │ 47338 B    │ 13702 B        │ 44% smaller   │ 92% BIGGER  │

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
          com.cognitect/transit-clj                     {:mvn/version "1.1.357"}
          com.github.clj-easy/graal-build-time          {:mvn/version "1.0.5"}
          com.taoensso/nippy                            {:mvn/version "3.7.0-beta1"}
-         com.s-exp/hako                                {:mvn/version "1.0.0-alpha31"}
+         com.s-exp/hako                                {:mvn/version "1.0.0-alpha32"}
          com.github.luben/zstd-jni                     {:mvn/version "1.5.7-11"}
          com.taoensso/timbre                           {:mvn/version "6.5.0"}
          me.lemire.integercompression/JavaFastPFOR     {:mvn/version "0.3.14"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,8 +3,8 @@
          babashka/babashka.pods                        {:mvn/version "0.2.0"}
          com.cognitect/transit-clj                     {:mvn/version "1.1.357"}
          com.github.clj-easy/graal-build-time          {:mvn/version "1.0.5"}
-         com.taoensso/nippy                            {:mvn/version "3.7.0-beta1"}
-         com.s-exp/hako                                {:mvn/version "1.0.0-alpha32"}
+         com.taoensso/nippy                            {:mvn/version "3.9.0-alpha2"}
+         com.s-exp/hako                                {:mvn/version "1.0.0-alpha47"}
          com.github.luben/zstd-jni                     {:mvn/version "1.5.7-11"}
          com.taoensso/timbre                           {:mvn/version "6.5.0"}
          me.lemire.integercompression/JavaFastPFOR     {:mvn/version "0.3.14"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,17 @@
 {:paths ["src" "target/classes"]
- :deps  {
-         org.clojure/clojure                           {:mvn/version "1.12.4"}
+ :deps  {org.clojure/clojure                           {:mvn/version "1.12.4"}
          babashka/babashka.pods                        {:mvn/version "0.2.0"}
          com.cognitect/transit-clj                     {:mvn/version "1.1.357"}
          com.github.clj-easy/graal-build-time          {:mvn/version "1.0.5"}
          com.taoensso/nippy                            {:mvn/version "3.7.0-beta1"}
-        com.github.luben/zstd-jni                     {:mvn/version "1.5.7-11"}
+         com.s-exp/hako                                {:mvn/version "1.0.0-alpha31"}
+         com.github.luben/zstd-jni                     {:mvn/version "1.5.7-11"}
          com.taoensso/timbre                           {:mvn/version "6.5.0"}
-        me.lemire.integercompression/JavaFastPFOR     {:mvn/version "0.3.14"}
+         me.lemire.integercompression/JavaFastPFOR     {:mvn/version "0.3.14"}
          metosin/jsonista                              {:mvn/version "1.0.0"}
          io.github.nextjournal/markdown                {:mvn/version "0.7.225"}
          nrepl/bencode                                 {:mvn/version "1.2.0"}
-        org.babashka/sci                              {:mvn/version "0.13.53"}
+         org.babashka/sci                              {:mvn/version "0.13.53"}
          org.clojure/tools.cli                         {:mvn/version "1.4.256"}
          org.clojars.huahaiy/dtlvnative-macosx-arm64   {:mvn/version "0.18.8"}
          org.clojars.huahaiy/dtlvnative-linux-arm64    {:mvn/version "0.18.8"}
@@ -21,26 +21,21 @@
          org.roaringbitmap/RoaringBitmap               {:mvn/version "1.6.14"}
          org.bouncycastle/bcpkix-jdk15on               {:mvn/version "1.70"}
          org.bouncycastle/bcprov-jdk15on               {:mvn/version "1.70"}
-        com.alipay.sofa/jraft-core                    {:mvn/version "1.4.1"
-                                                        :exclusions [org.rocksdb/rocksdbjni]}
-         }
+         com.alipay.sofa/jraft-core                    {:mvn/version "1.4.1"
+                                                        :exclusions [org.rocksdb/rocksdbjni]}}
 
  :deps/prep-lib {:alias  :build
                  :fn     compile-java
                  :ensure "target/classes"}
 
- :aliases {
-           :dev {
-                 :jvm-opts ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+ :aliases {:dev {:jvm-opts ["--add-opens=java.base/java.lang=ALL-UNNAMED"
                             "--add-opens=java.base/java.nio=ALL-UNNAMED"
                             "--add-opens=java.base/java.util=ALL-UNNAMED"
                             "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
                             "--enable-native-access=ALL-UNNAMED"
-                            "-Dclojure.compiler.direct-linking=true"]
-                 }
+                            "-Dclojure.compiler.direct-linking=true"]}
 
-           :pod   {
-                   :jvm-opts   ["--add-opens=java.base/java.lang=ALL-UNNAMED"
+           :pod   {:jvm-opts   ["--add-opens=java.base/java.lang=ALL-UNNAMED"
                                 "--add-opens=java.base/java.nio=ALL-UNNAMED"
                                 "--add-opens=java.base/java.util=ALL-UNNAMED"
                                 "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
@@ -49,14 +44,12 @@
                    :main-opts  ["-m" "pod.huahaiy.datalevin"]
                    :ns-default pod.huahaiy.datalevin
                    :exec-fn    run}
-           :test  {
-                   :extra-paths ["test"]
+           :test  {:extra-paths ["test"]
                    :jvm-opts    ["--add-opens=java.base/java.lang=ALL-UNNAMED"
                                  "--add-opens=java.base/java.nio=ALL-UNNAMED"
                                  "--add-opens=java.base/java.util=ALL-UNNAMED"
                                  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
                                  "--enable-native-access=ALL-UNNAMED"
-                                 "-Dclojure.compiler.direct-linking=true"]
-                   }
+                                 "-Dclojure.compiler.direct-linking=true"]}
            :build {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}}
                    :ns-default build}}}

--- a/src/datalevin/bits.clj
+++ b/src/datalevin/bits.clj
@@ -253,15 +253,19 @@
 (defn- get-data
   "Read data from a ByteBuffer. Phase-2 path: decodes hako bytes
   directly via a MemorySegment view of the ByteBuffer region, no
-  intermediate byte[] allocation."
+  intermediate byte[] allocation. Empty payloads (n == 0) yield nil;
+  negative `n` (post-v overruns remaining) throws."
   ([^ByteBuffer bb]
    (let [n (.remaining bb)]
      (when (pos? n)
        (codec/get-data-from-buffer! bb n))))
   ([^ByteBuffer bb post-v]
    (let [n (- (.remaining bb) (long post-v))]
-     (when (pos? n)
-       (codec/get-data-from-buffer! bb n)))))
+     (cond
+       (neg? n) (throw (IllegalStateException.
+                        (str "bits/get-data: post-v " post-v
+                             " exceeds remaining " (.remaining bb))))
+       (pos? n) (codec/get-data-from-buffer! bb n)))))
 
 (def ^:no-doc ^:const float-sign-idx 31)
 (def ^:no-doc ^:const double-sign-idx 63)

--- a/src/datalevin/bits.clj
+++ b/src/datalevin/bits.clj
@@ -16,7 +16,7 @@
    [datalevin.ints :as i]
    [datalevin.sparselist :as sl]
    [clojure.string :as s]
-   [taoensso.nippy :as nippy])
+   [datalevin.hako-codec :as codec])
   (:import
    [java.util Arrays UUID Date Base64 Base64$Decoder Base64$Encoder]
    [java.util.regex Pattern]
@@ -94,31 +94,18 @@
 
 (defn bigint-from-reader ^BigInteger [^String s] (BigInteger. s))
 
-;; nippy
+;; hako (was nippy)
 
 (defn serialize ^bytes
   [x]
-  (binding [nippy/*freeze-serializable-allowlist*
-            (if (seq c/*data-serializable-classes*)
-              (into nippy/*thaw-serializable-allowlist*
-                    c/*data-serializable-classes*)
-              nippy/*thaw-serializable-allowlist*)]
-    (if (instance? java.lang.Class x)
-      (u/raise "Unfreezable type: java.lang.Class" {})
-      (nippy/fast-freeze x))))
+  (if (instance? java.lang.Class x)
+    (u/raise "Unfreezable type: java.lang.Class" {})
+    (codec/fast-freeze x)))
 
 (defn deserialize
   "Deserialize from bytes. "
   [^bytes bs]
-  (binding [nippy/*thaw-serializable-allowlist*
-            (if (seq c/*data-serializable-classes*)
-              (into nippy/*thaw-serializable-allowlist*
-                    c/*data-serializable-classes*)
-              nippy/*thaw-serializable-allowlist*)]
-    (try
-      (nippy/fast-thaw bs)
-      (catch Exception _
-        (nippy/thaw bs)))))
+  (codec/fast-thaw bs))
 
 ;; bitmap
 
@@ -158,15 +145,15 @@
   [bitmaps]
   (when-not (empty? bitmaps)
     (FastAggregation/and
-      ^"[Lorg.roaringbitmap.RoaringBitmap;"
-      (into-array RoaringBitmap bitmaps))))
+     ^"[Lorg.roaringbitmap.RoaringBitmap;"
+     (into-array RoaringBitmap bitmaps))))
 
 (defn bitmaps-or
   [bitmaps]
   (when-not (empty? bitmaps)
     (FastAggregation/or
-      ^"[Lorg.roaringbitmap.RoaringBitmap;"
-      (into-array RoaringBitmap bitmaps))))
+     ^"[Lorg.roaringbitmap.RoaringBitmap;"
+     (into-array RoaringBitmap bitmaps))))
 
 (defn bitmap-or
   [a b]
@@ -264,12 +251,17 @@
   (get-bytes bf (- (.remaining bf) post-v)))
 
 (defn- get-data
-  "Read data from a ByteBuffer"
+  "Read data from a ByteBuffer. Phase-2 path: decodes hako bytes
+  directly via a MemorySegment view of the ByteBuffer region, no
+  intermediate byte[] allocation."
   ([^ByteBuffer bb]
-   (when-let [bs (get-bytes bb)]
-     (deserialize bs)))
+   (let [n (.remaining bb)]
+     (when (pos? n)
+       (codec/get-data-from-buffer! bb n))))
   ([^ByteBuffer bb post-v]
-   (when-let [bs (get-bytes-val bb post-v)] (deserialize bs))))
+   (let [n (- (.remaining bb) (long post-v))]
+     (when (pos? n)
+       (codec/get-data-from-buffer! bb n)))))
 
 (def ^:no-doc ^:const float-sign-idx 31)
 (def ^:no-doc ^:const double-sign-idx 63)
@@ -284,9 +276,9 @@
 (defn- put-instant
   [^ByteBuffer bf x]
   (.putLong bf (code-instant
-                 (if (inst? x)
-                   (inst-ms x)
-                   (u/raise "Expect an inst? value" {:value x})))))
+                (if (inst? x)
+                  (inst-ms x)
+                  (u/raise "Expect an inst? value" {:value x})))))
 
 (defn- decode-float
   [x]
@@ -408,7 +400,12 @@
         ^int scale        (get-int bb)]
     (BigDecimal. value scale)))
 
-(defn- put-data [^ByteBuffer bb x] (put-bytes bb (serialize x)))
+(defn- put-data [^ByteBuffer bb x]
+  ;; Phase-2 path: hako encodes into a reusable arena-backed segment,
+  ;; then copies segment → ByteBuffer directly. Skips the byte[]
+  ;; intermediate that `serialize` + `put-bytes` allocate on every
+  ;; LMDB write.
+  (codec/put-data-into-buffer! bb x))
 
 (defn- put-uuid
   [bf ^UUID val]
@@ -500,7 +497,7 @@
 (defn- string-bytes
   [^String v]
   (wrap-extrema
-    v c/min-bytes c/max-bytes (.getBytes v StandardCharsets/UTF_8)))
+   v c/min-bytes c/max-bytes (.getBytes v StandardCharsets/UTF_8)))
 
 (defn- key-sym-bytes
   [x]
@@ -604,8 +601,8 @@
     -10 (put-double bf (wrap-extrema v Double/NEGATIVE_INFINITY
                                      Double/POSITIVE_INFINITY v))
     -9  (put-long bf (code-instant
-                       (wrap-extrema v Long/MIN_VALUE Long/MAX_VALUE
-                                     (.getTime ^Date v))))
+                      (wrap-extrema v Long/MIN_VALUE Long/MAX_VALUE
+                                    (.getTime ^Date v))))
     -8  (put-long bf (wrap-extrema v c/e0 Long/MAX_VALUE v))
     -7  (put-uuid bf (wrap-extrema v c/min-uuid c/max-uuid v))
     -3  (put-byte bf (wrap-extrema v c/false-value c/true-value
@@ -622,8 +619,8 @@
                         :db.value/sysMax c/tuple-max-bytes
                         (key-sym-bytes v)))
     -6  (put-bytes bf (wrap-extrema
-                        v c/min-bytes c/tuple-max-bytes
-                        (.getBytes ^String v StandardCharsets/UTF_8)))
+                       v c/min-bytes c/tuple-max-bytes
+                       (.getBytes ^String v StandardCharsets/UTF_8)))
     -14 (put-bytes bf (wrap-extrema v c/min-bytes c/tuple-max-bytes
                                     (encode-bigdec v)))
     -15 (put-bytes bf (wrap-extrema v c/min-bytes c/tuple-max-bytes
@@ -716,9 +713,9 @@
              post-vs (->> (get-tuple-sizes bf c outer-post-v)
                           reverse
                           (reduce
-                            (fn [vs s]
-                              (conj vs (+ ^long s (inc ^long (first vs)))))
-                            '(0))
+                           (fn [vs s]
+                             (conj vs (+ ^long s (inc ^long (first vs)))))
+                           '(0))
                           rest
                           (map #(+ ^long % c 2 outer-post-v))
                           vec)
@@ -739,8 +736,8 @@
          post-vs (->> (get-tuple-sizes bf c outer-post-v)
                       reverse
                       (reduce
-                        (fn [vs s] (conj vs (+ ^long s ^long (first vs))))
-                        '(0))
+                       (fn [vs s] (conj vs (+ ^long s ^long (first vs))))
+                       '(0))
                       rest
                       (map #(+ ^long % c 1 outer-post-v))
                       vec)
@@ -777,16 +774,16 @@
 (defn- tuple-bytes
   [v t]
   (wrap-extrema
-    v c/min-bytes c/max-bytes
-    (let [t        (into [] (map dl-type->raw) t)
-          tuple-bf ^ByteBuffer (bf/get-array-buffer)]
-      (if (= 1 (count t))
-        (put-homo-tuple tuple-bf v (nth t 0))
-        (put-hete-tuple tuple-bf v t))
-      (let [res (Arrays/copyOfRange (.array tuple-bf)
-                                    0 (.position tuple-bf))]
-        (bf/return-array-buffer tuple-bf)
-        res))))
+   v c/min-bytes c/max-bytes
+   (let [t        (into [] (map dl-type->raw) t)
+         tuple-bf ^ByteBuffer (bf/get-array-buffer)]
+     (if (= 1 (count t))
+       (put-homo-tuple tuple-bf v (nth t 0))
+       (put-hete-tuple tuple-bf v t))
+     (let [res (Arrays/copyOfRange (.array tuple-bf)
+                                   0 (.position tuple-bf))]
+       (bf/return-array-buffer tuple-bf)
+       res))))
 
 (defn- val-bytes
   "Turn datalog value into bytes according to :db/valueType"
@@ -989,7 +986,7 @@
      ;; user facing
      :string         (do (put-byte bf (raw-header x :string))
                          (put-bytes
-                           bf (.getBytes ^String x StandardCharsets/UTF_8)))
+                          bf (.getBytes ^String x StandardCharsets/UTF_8)))
      :bigint         (do (put-byte bf (raw-header x :bigint))
                          (put-bigint bf x))
      :bigdec         (do (put-byte bf (raw-header x :bigdec))
@@ -1061,7 +1058,7 @@
   [^ByteBuffer bf data type]
   (when-some [x data]
     (.clear bf)
-    (put-buffer bf x type )
+    (put-buffer bf x type)
     (.flip bf)))
 
 (defn read-buffer

--- a/src/datalevin/conn.clj
+++ b/src/datalevin/conn.clj
@@ -201,28 +201,28 @@
   [conn]
   (when conn
     (let [detached? (volatile! false)]
-    (try
-      (when-not (closed? conn)
-        (when-let [store (.-store ^DB @conn)]
-          (case (release-shared-local-store! store)
-            :detached
-            (vreset! detached? true)
+      (try
+        (when-not (closed? conn)
+          (when-let [store (.-store ^DB @conn)]
+            (case (release-shared-local-store! store)
+              :detached
+              (vreset! detached? true)
 
-            :close
-            (do
-              (i/close store)
-              (when (i/closed? store)
-                (vreset! detached? true))))))
-      (finally
-        (when (or @detached? (closed? conn))
-          (remove-conn (:dir (meta conn)) conn)
-          (when-let [listeners (:listeners (meta conn))]
-            (when (instance? clojure.lang.IAtom listeners)
-              (reset! listeners {})))
-          (when (instance? clojure.lang.IAtom conn)
-            (reset! conn nil))
-          (alter-conn-meta! conn dissoc :dir :remote-store-opts-cache))
-        (shutdown-transact-async-executor-if-idle!)))))
+              :close
+              (do
+                (i/close store)
+                (when (i/closed? store)
+                  (vreset! detached? true))))))
+        (finally
+          (when (or @detached? (closed? conn))
+            (remove-conn (:dir (meta conn)) conn)
+            (when-let [listeners (:listeners (meta conn))]
+              (when (instance? clojure.lang.IAtom listeners)
+                (reset! listeners {})))
+            (when (instance? clojure.lang.IAtom conn)
+              (reset! conn nil))
+            (alter-conn-meta! conn dissoc :dir :remote-store-opts-cache))
+          (shutdown-transact-async-executor-if-idle!)))))
   nil)
 
 (defn closed?
@@ -343,7 +343,7 @@
                    s1#     (volatile! nil)
                    res1#   (l/with-transaction-kv [kv1# kv# tx-timeout-opt#]
                              (let [conn1# (atom (db/transfer
-                                                  db# (s/transfer s# kv1#))
+                                                 db# (s/transfer s# kv1#))
                                                 :meta (meta orig-conn#))
                                    res#   (let [~conn conn1#]
                                             ~@body)]
@@ -387,14 +387,14 @@
       (db/disable-cache store)
       (try
         (let [report (u/repeat-try-catch
-                       c/+in-tx-overflow-times+
-                       l/resized?
-                       (with db tx-data tx-meta))]
+                      c/+in-tx-overflow-times+
+                      l/resized?
+                      (with db tx-data tx-meta))]
           (reset! conn (db/carry-runtime-opts (:db-after report) db))
           (assoc report :db-after @conn))
-          (finally
-            (when-not old
-              (db/enable-cache (.-store ^DB @conn))))))))
+        (finally
+          (when-not old
+            (db/enable-cache (.-store ^DB @conn))))))))
 
 (defn- direct-local-blind-transact!
   [conn prepared tx-meta]
@@ -413,7 +413,7 @@
                           db1    ^DB    (db/transfer db store1)]
                       (vreset! prepared-store store1)
                       (let [[report info] (db/stamp-blind-local-tx
-                                            db1 prepared tx-meta)]
+                                           db1 prepared tx-meta)]
                         (db/commit-prepared-tx-data! db1 (:tx-data report))
                         [report info])))
                   new-store      ^Store (s/transfer ^Store @prepared-store kv)
@@ -421,8 +421,8 @@
                                         (long (or (i/last-modified new-store)
                                                   0)))
                   new-db         (db/carry-runtime-opts
-                                   (db/new-db new-store new-info)
-                                   db)]
+                                  (db/new-db new-store new-info)
+                                  db)]
               (reset! conn new-db)
               (assoc report :db-after @conn))
             (finally
@@ -455,9 +455,9 @@
       (db/disable-cache store)
       (try
         (let [report (u/repeat-try-catch
-                       c/+in-tx-overflow-times+
-                       l/resized?
-                       (with db tx-data tx-meta true))]
+                      c/+in-tx-overflow-times+
+                      l/resized?
+                      (with db tx-data tx-meta true))]
           (with-transaction [c conn]
             (assert (active-conn-structural? c))
             (db/commit-prepared-tx-data! @c (:tx-data report) report))
@@ -533,12 +533,12 @@
 (defn- current-thread-holds-store-write-lock?
   [store]
   (boolean
-    (or
-      (when-let [write-lock (l/write-txn store)]
-        (Thread/holdsLock write-lock))
-      (when (instance? Store store)
-        (when-let [lmdb-write-lock (l/write-txn (.-lmdb ^Store store))]
-          (Thread/holdsLock lmdb-write-lock))))))
+   (or
+    (when-let [write-lock (l/write-txn store)]
+      (Thread/holdsLock write-lock))
+    (when (instance? Store store)
+      (when-let [lmdb-write-lock (l/write-txn (.-lmdb ^Store store))]
+        (Thread/holdsLock lmdb-write-lock))))))
 
 (defn- wal-sync-queue-profile-from-opts
   [opts]
@@ -574,11 +574,11 @@
             (cond
               (instance? Store store)
               (wal-sync-queue-profile-from-opts
-                (i/env-opts (.-lmdb ^Store store)))
+               (i/env-opts (.-lmdb ^Store store)))
 
               (instance? DatalogStore store)
               (wal-sync-queue-profile-from-opts
-                (cached-remote-store-opts conn store))
+               (cached-remote-store-opts conn store))
 
               :else nil)))))))
 
@@ -666,13 +666,13 @@
   ([conn db] (reset-conn! conn db nil))
   ([conn db tx-meta]
    (let [report (db/map->TxReport
-                  {:db-before @conn
-                   :db-after  db
-                   :tx-data   (let [ds (db/-datoms db :eav nil nil nil)]
-                                (u/concatv
-                                  (mapv #(assoc % :added false) ds)
-                                  ds))
-                   :tx-meta   tx-meta})]
+                 {:db-before @conn
+                  :db-after  db
+                  :tx-data   (let [ds (db/-datoms db :eav nil nil nil)]
+                               (u/concatv
+                                (mapv #(assoc % :added false) ds)
+                                ds))
+                  :tx-meta   tx-meta})]
      (reset! conn db)
      (doseq [[_ callback] (some-> (:listeners (meta conn)) (deref))]
        (callback report))
@@ -773,9 +773,9 @@
   []
   (let [threads (.availableProcessors (Runtime/getRuntime))
         workers (ThreadPoolExecutor.
-                  threads threads 0 TimeUnit/MILLISECONDS
-                  (ArrayBlockingQueue. (* 4 threads))
-                  (ThreadPoolExecutor$CallerRunsPolicy.))
+                 threads threads 0 TimeUnit/MILLISECONDS
+                 (ArrayBlockingQueue. (* 4 threads))
+                 (ThreadPoolExecutor$CallerRunsPolicy.))
         executor (a/->AsyncExecutor (Executors/newSingleThreadExecutor)
                                     workers
                                     (LinkedBlockingQueue.)
@@ -810,11 +810,11 @@
       (let [^LinkedBlockingQueue event-queue (.-event-queue executor)
             workers                         (.-workers executor)
             ^ThreadPoolExecutor worker-pool (when (instance? ThreadPoolExecutor workers)
-                                               workers)
+                                              workers)
             workers-idle?                   (if worker-pool
-                                             (and (zero? (.getActiveCount worker-pool))
-                                                  (.isEmpty (.getQueue worker-pool)))
-                                             true)]
+                                              (and (zero? (.getActiveCount worker-pool))
+                                                   (.isEmpty (.getQueue worker-pool)))
+                                              true)]
         (when (and (.isEmpty event-queue) workers-idle?)
           (a/stop executor)
           (reset! transact-async-executor-atom nil)))))
@@ -943,9 +943,9 @@
       (when (< i n)
         (let [^SyncQueuedReq req (.get requests i)
               ^TxReport report (with db
-                                 (.-tx-data req)
-                                 (.-tx-meta req)
-                                 true)]
+                                     (.-tx-data req)
+                                     (.-tx-meta req)
+                                     true)]
           (aset reports i report)
           (recur (inc i) (:db-after report)))))))
 
@@ -970,8 +970,8 @@
                                                  (.-tx-data req)
                                                  (.-tx-meta req))]
                 (deliver-sync-queued-success!
-                  req
-                  (finalize-sync-queued-report report @conn))))
+                 req
+                 (finalize-sync-queued-report report @conn))))
             (catch Throwable e
               (deliver-sync-queued-error! req e)))
           nil)
@@ -988,10 +988,10 @@
             (let [db-after @conn]
               (dotimes [i n]
                 (deliver-sync-queued-success!
-                  (.get requests i)
-                  (finalize-sync-queued-report
-                    ^TxReport (aget reports i)
-                    db-after))))
+                 (.get requests i)
+                 (finalize-sync-queued-report
+                  ^TxReport (aget reports i)
+                  db-after))))
             (catch Throwable e
               (dotimes [i n]
                 (deliver-sync-queued-error! (.get requests i) e))))

--- a/src/datalevin/constants.clj
+++ b/src/datalevin/constants.clj
@@ -280,7 +280,6 @@
 
 (def ^:no-doc ^:const +value-compress-dict-size+ 32) ;; in KB
 
-
 ;; search
 
 (def ^:const default-domain "datalevin")
@@ -412,7 +411,10 @@
 (def ^:no-doc ^:const message-header-size 5) ; bytes, 1 type + 4 length
 
 (def ^:no-doc ^:const message-format-transit (unchecked-byte 0x01))
-(def ^:no-doc ^:const message-format-nippy (unchecked-byte 0x02))
+;; Wire-format tag byte for hako-encoded messages. Value kept at 0x02
+;; (was `message-format-nippy` on master) for wire compatibility with
+;; the existing protocol frame.
+(def ^:no-doc ^:const message-format-hako (unchecked-byte 0x02))
 (def ^:no-doc ^:const message-format-mask 0x0F)
 (def ^:no-doc ^:const message-flag-zstd 0x10)
 
@@ -907,7 +909,6 @@ values means trust sampled high ratio more."}
        :doc     "Change ratio of an attribute's values, beyond which re-sampling will be done"}
   sample-change-ratio 0.05)
 
-
 (def ^{:dynamic true
        :doc     "Max milliseconds to wait for a tuple before failing. nil to wait forever."}
   query-pipe-timeout 3000000)
@@ -919,7 +920,6 @@ values means trust sampled high ratio more."}
 (def ^{:dynamic true
        :doc     "Batch size for pipelined scans. Tuples are buffered, sorted, then scanned in batch for sequential seeks. Set to 0 to disable batching."}
   query-pipe-batch-size 12384)
-
 
 ;; search engine
 

--- a/src/datalevin/datom.clj
+++ b/src/datalevin/datom.clj
@@ -220,7 +220,7 @@
 (def datom->vec-xf (map datom-eav))
 
 (hext/register-user-tag!
- 0x10000001                             ; private range, subtag 1 = datom
+ 1                                      ; subtag 1 = datom (wire id 0x10000001)
  Datom
  (fn write-datom [^Writer w ^Datom d]
    (.putI64 w (.-e d))
@@ -228,8 +228,5 @@
    (.writeAny w (.-v d))
    (.writeAny w (.-tx d)))
  (fn read-datom [^Reader r]
-   (let [e  (.getI64 r)
-         a  (.readAny r)
-         v  (.readAny r)
-         tx (.readAny r)]
-     (datom-from-reader (if tx [e a v tx] [e a v])))))
+   ;; write side always emits tx (possibly nil); 4-arity `datom` accepts nil.
+   (datom (.getI64 r) (.readAny r) (.readAny r) (.readAny r))))

--- a/src/datalevin/datom.clj
+++ b/src/datalevin/datom.clj
@@ -10,10 +10,12 @@
 (ns ^:no-doc datalevin.datom
   "Datom object"
   (:require
-   [taoensso.nippy :as nippy]
+   [datalevin.hako-codec :as codec]
+   [s-exp.hako.ext :as hext]
    [datalevin.constants :refer [tx0]]
    [datalevin.util :refer [combine-hashes combine-cmp defcomp]])
   (:import
+   [com.s_exp.hako Reader Writer]
    [datalevin.utl BitOps]
    [java.util Arrays]
    [java.io DataInput DataOutput]))
@@ -151,7 +153,7 @@
              :tx    (datom (.-e d) (.-a d) (.-v d) v (datom-added d))
              :added (datom (.-e d) (.-a d) (.-v d) (datom-tx d) v)
              (throw (IllegalArgumentException.
-                      (str "invalid key for #datalevin/Datom: " k))))]
+                     (str "invalid key for #datalevin/Datom: " k))))]
     (if m (with-meta d' m) d')))
 
 ;; printing and reading
@@ -195,17 +197,17 @@
 
 (defcomp cmp-datoms-eavt [^Datom d1, ^Datom d2]
   (combine-cmp
-    (long-compare (.-e d1) (.-e d2))
-    (nil-cmp (.-a d1) (.-a d2))
-    (nil-cmp-type (.-v d1) (.-v d2))
-    (long-compare (datom-tx d1) (datom-tx d2))))
+   (long-compare (.-e d1) (.-e d2))
+   (nil-cmp (.-a d1) (.-a d2))
+   (nil-cmp-type (.-v d1) (.-v d2))
+   (long-compare (datom-tx d1) (datom-tx d2))))
 
 (defcomp cmp-datoms-avet [^Datom d1, ^Datom d2]
   (combine-cmp
-    (nil-cmp (.-a d1) (.-a d2))
-    (nil-cmp-type (.-v d1) (.-v d2))
-    (long-compare (.-e d1) (.-e d2))
-    (long-compare (datom-tx d1) (datom-tx d2))))
+   (nil-cmp (.-a d1) (.-a d2))
+   (nil-cmp-type (.-v d1) (.-v d2))
+   (long-compare (.-e d1) (.-e d2))
+   (long-compare (datom-tx d1) (datom-tx d2))))
 
 (defn datom-e [^Datom d] (.-e d))
 
@@ -217,20 +219,17 @@
 
 (def datom->vec-xf (map datom-eav))
 
-(nippy/extend-freeze Datom :datalevin/datom
-    [^Datom x ^DataOutput out]
-  (.writeLong out (.-e x))
-  (nippy/freeze-to-out! out (.-a x))
-  (nippy/freeze-to-out! out (.-v x))
-  (when-let [tx (.-tx x)]
-    (nippy/freeze-to-out! out tx)))
-
-(nippy/extend-thaw :datalevin/datom
-                   [^DataInput in]
-  (let [vs [(.readLong in)
-            (nippy/thaw-from-in! in)
-            (nippy/thaw-from-in! in)]
-        tx (nippy/thaw-from-in! in)]
-                     (datom-from-reader (if tx
-                                          (conj vs tx)
-                                          vs))))
+(hext/register-user-tag!
+ 0x10000001                             ; private range, subtag 1 = datom
+ Datom
+ (fn write-datom [^Writer w ^Datom d]
+   (.putI64 w (.-e d))
+   (.writeAny w (.-a d))
+   (.writeAny w (.-v d))
+   (.writeAny w (.-tx d)))
+ (fn read-datom [^Reader r]
+   (let [e  (.getI64 r)
+         a  (.readAny r)
+         v  (.readAny r)
+         tx (.readAny r)]
+     (datom-from-reader (if tx [e a v tx] [e a v])))))

--- a/src/datalevin/dump.clj
+++ b/src/datalevin/dump.clj
@@ -14,7 +14,7 @@
    [clojure.string :as str]
    [clojure.pprint :as p]
    [clojure.edn :as edn]
-   [taoensso.nippy :as nippy]
+   [datalevin.hako-codec :as codec]
    [datalevin.util :as u]
    [datalevin.constants :as c]
    [datalevin.conn :as conn]
@@ -62,10 +62,10 @@
   [attr props]
   (when (:db/fulltext props)
     (vec
-      (distinct
-        (cond-> (vec (or (seq (:db.fulltext/domains props))
-                         [c/default-domain]))
-          (:db.fulltext/autoDomain props) (conj (u/keyword->string attr)))))))
+     (distinct
+      (cond-> (vec (or (seq (:db.fulltext/domains props))
+                       [c/default-domain]))
+        (:db.fulltext/autoDomain props) (conj (u/keyword->string attr)))))))
 
 (defn- vector-attr-domains
   [attr props]
@@ -76,10 +76,10 @@
   [attr props]
   (when (:db/embedding props)
     (vec
-      (distinct
-        (cond-> (vec (or (seq (:db.embedding/domains props))
-                         [c/default-domain]))
-          (:db.embedding/autoDomain props) (conj (attr-domain attr)))))))
+     (distinct
+      (cond-> (vec (or (seq (:db.embedding/domains props))
+                       [c/default-domain]))
+        (:db.embedding/autoDomain props) (conj (attr-domain attr)))))))
 
 (defn- idoc-attr-domain
   [attr props]
@@ -89,14 +89,14 @@
 (defn- domains-from-schema
   [schema f]
   (reduce-kv
-    (fn [domains attr props]
-      (let [v (f attr props)]
-        (cond
-          (nil? v) domains
-          (coll? v) (into domains v)
-          :else (conj domains v))))
-    #{}
-    schema))
+   (fn [domains attr props]
+     (let [v (f attr props)]
+       (cond
+         (nil? v) domains
+         (coll? v) (into domains v)
+         :else (conj domains v))))
+   #{}
+   schema))
 
 (defn- fulltext-dbis
   [domain]
@@ -129,11 +129,11 @@
                                 (domains-from-schema schema embedding-attr-domains))
         idoc-domains      (domains-from-schema schema idoc-attr-domain)]
     (set
-      (concat
-        (mapcat fulltext-dbis search-domains)
-        (mapcat vector-dbis vector-domains)
-        (mapcat #(vector-dbis (embedding-index-domain %)) embedding-domains)
-        (mapcat idoc-dbis idoc-domains)))))
+     (concat
+      (mapcat fulltext-dbis search-domains)
+      (mapcat vector-dbis vector-domains)
+      (mapcat #(vector-dbis (embedding-index-domain %)) embedding-domains)
+      (mapcat idoc-dbis idoc-domains)))))
 
 (defn- user-kv-dbis
   [dbis schema opts]
@@ -154,10 +154,10 @@
 
     (map? v)
     (reduce-kv
-      (fn [m k v]
-        (assoc m k (idoc-dump-value v)))
-      {}
-      v)
+     (fn [m k v]
+       (assoc m k (idoc-dump-value v)))
+     {}
+     v)
 
     (vector? v)
     (mapv idoc-dump-value v)
@@ -192,12 +192,12 @@
   ([conn data-output]
    (if data-output
      (let [schema (conn/schema conn)]
-       (nippy/freeze-to-out!
-         data-output
-         [(conn/opts conn)
+       (codec/freeze-to-out!
+        data-output
+        [(conn/opts conn)
          schema
          (map (fn [^Datom datom] (datom-dump-row schema datom))
-               (db/-datoms @conn :eav nil nil nil))]))
+              (db/-datoms @conn :eav nil nil nil))]))
      (dump-datalog conn))))
 
 (defn- dump-datalog-section
@@ -264,12 +264,12 @@
 (defn- normalize-legacy-ha-nil-sentinels
   [opts]
   (reduce
-    (fn [m k]
-      (if (= nippy-meta-protocol-key (get m k))
-        (assoc m k nil)
-        m))
-    (or opts {})
-    legacy-ha-nil-sentinel-keys))
+   (fn [m k]
+     (if (= nippy-meta-protocol-key (get m k))
+       (assoc m k nil)
+       m))
+   (or opts {})
+   legacy-ha-nil-sentinel-keys))
 
 (defn- load-datalog-from-first*
   [dir read-form first-form schema opts stop?]
@@ -293,8 +293,8 @@
 (defn- load-datalog-section
   [dir read-form schema opts]
   (load-datalog-from-first*
-    dir read-form (read-form) schema opts
-    #(and (map? %) (= :datalog (get % section-end-key)))))
+   dir read-form (read-form) schema opts
+   #(and (map? %) (= :datalog (get % section-end-key)))))
 
 (defn- load-mixed
   [dir read-form schema opts]
@@ -336,10 +336,10 @@
           (let [lmdb (l/open-kv dir)]
             (try
               (l/load-all-forms
-                lmdb
-                (cons first-form
-                      (take-while #(not= ::EOF %)
-                                  (repeatedly read-form))))
+               lmdb
+               (cons first-form
+                     (take-while #(not= ::EOF %)
+                                 (repeatedly read-form))))
               (finally
                 (i/close-kv lmdb))))
 
@@ -363,15 +363,15 @@
   ([dir in schema opts nippy?]
    (if nippy?
      (try
-       (let [[old-opts old-schema datoms] (nippy/thaw-from-in! in)
+       (let [[old-opts old-schema datoms] (codec/thaw-from-in! in)
              old-opts                     (normalize-legacy-ha-nil-sentinels
-                                            old-opts)
+                                           old-opts)
              new-opts                     (merge old-opts opts)
              new-schema                   (merge old-schema schema)
              db                           (db/init-db
-                                            (for [d datoms]
-                                              (load-datom new-schema d))
-                                            dir new-schema new-opts)]
+                                           (for [d datoms]
+                                             (load-datom new-schema d))
+                                           dir new-schema new-opts)]
          (db/close-db db))
        (catch Exception e
          (u/raise "Error loading nippy file into Datalog DB: " e {})))

--- a/src/datalevin/dump.clj
+++ b/src/datalevin/dump.clj
@@ -374,7 +374,12 @@
                                            dir new-schema new-opts)]
          (db/close-db db))
        (catch Exception e
-         (u/raise "Error loading nippy file into Datalog DB: " e {})))
+         (u/raise
+          "Failed to load binary dump into Datalog DB. If this dump was
+           produced by a pre-hako Datalevin, re-dump it with the old
+           version to the EDN format (drop the `--nippy` flag on
+           `dtlv dump`) and reload here."
+          e {})))
      (load-datalog dir in schema opts)))
   ([dir in schema opts]
    (try

--- a/src/datalevin/entity.clj
+++ b/src/datalevin/entity.clj
@@ -254,7 +254,7 @@
       e)))
 
 (hext/register-user-tag!
- 0x10000008                             ; private range, subtag 8 = entity
+ 8                                      ; subtag 8 = entity (wire id 0x10000008)
  Entity
  (fn write-entity [^Writer w ^Entity x]
    (.writeAny w (ent->map x)))

--- a/src/datalevin/entity.clj
+++ b/src/datalevin/entity.clj
@@ -16,14 +16,14 @@
    [datalevin.remote :as r]
    [datalevin.util :as u]
    [datalevin.interface :refer [db-name]]
-   [taoensso.nippy :as nippy]
+   [s-exp.hako.ext :as hext]
    [clojure.set :as set]
    [datalevin.query-util :as qu])
   (:import
+   [com.s_exp.hako Reader Writer]
    [datalevin.db DB]
    [datalevin.interface IStore]
-   [datalevin.remote DatalogStore]
-   [java.io DataInput DataOutput]))
+   [datalevin.remote DatalogStore]))
 
 (declare entity ->Entity equiv-entity lookup-entity touch entity->txs
          lookup-stage-then-entity)
@@ -114,8 +114,8 @@
   (let [staged (not-empty (.-tbd e))
         ent    (assoc @(.cache e) :db/id (.eid e))]
     (.write w (pr-str
-                (cond-> ent
-                  staged (assoc :<STAGED> staged))))))
+               (cond-> ent
+                 staged (assoc :<STAGED> staged))))))
 
 (defn- rschema->attr-types
   [{ref-attrs  :db.type/ref
@@ -133,8 +133,6 @@
 (defn- db->attr-types [db]
   (mem-rschema->attr-types (db/-rschema db)))
 
-
-
 (defn lookup-stage-then-entity
   ([e k] (lookup-stage-then-entity e k nil))
   ([^Entity e k default-value]
@@ -150,37 +148,37 @@
         {:keys [ref-many-rattrs ref-many-attrs]}
         (db->attr-types db)]
     (into
-      []
-      (mapcat
-        (fn [[k [meta v]]]
-          (let [{:keys [op]} meta]
-            (if (or (ref-many-attrs k) (ref-many-rattrs k))
-              (let [v (if (qu/lookup-ref? v)
-                        [v]
-                        (u/ensure-vec v))]
-                (case op
-                  :assoc   [[:db.fn/retractAttribute eid k]
-                            {:db/id eid
-                             k      (mapv (fn [e] (or (:db/id e) e)) v)}]
-                  :add     [{:db/id eid
-                             k      (mapv (fn [e] (or (:db/id e) e)) v)}]
-                  :dissoc  [[:db.fn/retractAttribute eid k]]
-                  :retract (into []
-                                 (map (fn [e]
-                                        [:db/retract eid k (:db/id e)]))
-                                 v)))
+     []
+     (mapcat
+      (fn [[k [meta v]]]
+        (let [{:keys [op]} meta]
+          (if (or (ref-many-attrs k) (ref-many-rattrs k))
+            (let [v (if (qu/lookup-ref? v)
+                      [v]
+                      (u/ensure-vec v))]
               (case op
-                (:dissoc :retract) [[:db.fn/retractAttribute eid k]]
-                (:assoc :add)      [[:db/add eid k v]])))))
-      (.-tbd e))))
+                :assoc   [[:db.fn/retractAttribute eid k]
+                          {:db/id eid
+                           k      (mapv (fn [e] (or (:db/id e) e)) v)}]
+                :add     [{:db/id eid
+                           k      (mapv (fn [e] (or (:db/id e) e)) v)}]
+                :dissoc  [[:db.fn/retractAttribute eid k]]
+                :retract (into []
+                               (map (fn [e]
+                                      [:db/retract eid k (:db/id e)]))
+                               v)))
+            (case op
+              (:dissoc :retract) [[:db.fn/retractAttribute eid k]]
+              (:assoc :add)      [[:db/add eid k v]])))))
+     (.-tbd e))))
 
 (defn entity? [x] (instance? Entity x))
 
 (defn- equiv-entity [^Entity this that]
   (and
-    (instance? Entity that)
-    (identical? (.-db this) (.-db ^Entity that)) ; `=` and `hash` on db is expensive
-    (= (.-eid this) (.-eid ^Entity that))))
+   (instance? Entity that)
+   (identical? (.-db this) (.-db ^Entity that)) ; `=` and `hash` on db is expensive
+   (= (.-eid this) (.-eid ^Entity that))))
 
 (defn- lookup-entity
   ([this attr] (lookup-entity this attr nil))
@@ -202,11 +200,11 @@
 (defn touch-components [db a->v]
   (reduce-kv (fn [acc a v]
                (assoc acc a
-                          (if (db/component? db a)
-                            (if (db/multival? db a)
-                              (set (map touch v))
-                              (touch v))
-                            v)))
+                      (if (db/component? db a)
+                        (if (db/multival? db a)
+                          (set (map touch v))
+                          (touch v))
+                        v)))
              {} a->v))
 
 (defn- datoms->cache [db datoms]
@@ -246,10 +244,6 @@
       (assoc m :touched true :cache @(.-cache x))
       m)))
 
-(nippy/extend-freeze Entity :datalevin/entity
-                     [^Entity x ^DataOutput out]
-                     (nippy/freeze-to-out! out (ent->map x)))
-
 (defn- map->ent
   [{:keys [db-name touched cache db/id]}]
   (let [db (let [^DB db (@db/dbs db-name)]
@@ -259,6 +253,10 @@
       (load-cache e cache)
       e)))
 
-(nippy/extend-thaw :datalevin/entity
-                   [^DataInput in]
-                   (map->ent (nippy/thaw-from-in! in)))
+(hext/register-user-tag!
+ 0x10000008                             ; private range, subtag 8 = entity
+ Entity
+ (fn write-entity [^Writer w ^Entity x]
+   (.writeAny w (ent->map x)))
+ (fn read-entity [^Reader r]
+   (map->ent (.readAny r))))

--- a/src/datalevin/hako_codec.clj
+++ b/src/datalevin/hako_codec.clj
@@ -66,12 +66,14 @@
     (hako/decode-into! rd (.asSlice ^MemorySegment seg 0 n) {:cache-idents true})))
 
 (defn freeze
-  "Encode `v` to a fresh byte[]. Convenience mirror of nippy/freeze."
+  "Encode `v` to a fresh byte[]. Signature-compatible with the
+  former `nippy/freeze` for drop-in replacement."
   ^bytes [v]
   (hako/encode v))
 
 (defn thaw
-  "Decode a hako-encoded byte[]. Convenience mirror of nippy/thaw."
+  "Decode a hako-encoded byte[]. Signature-compatible with the
+  former `nippy/thaw` for drop-in replacement."
   [^bytes bs]
   (hako/decode bs {:cache-idents true}))
 

--- a/src/datalevin/hako_codec.clj
+++ b/src/datalevin/hako_codec.clj
@@ -1,0 +1,71 @@
+(ns datalevin.hako-codec
+  "hako-backed replacement for nippy's freeze-to-out! / thaw-from-in!.
+
+  Matches nippy's signature so call sites can swap import + fn refs.
+  Uses a thread-local reusable Writer + Reader to amortize arena
+  setup across calls. The `DataOutput` / `DataInput` boundary
+  forces an intermediate `byte[]` copy — genuinely unavoidable
+  without refactoring callers to `MemorySegment`.
+
+  Wire format per call: `<u32 length LE><hako-encoded payload>`.
+  Length-prefix lets multiple values interleave in the same stream."
+  (:require [s-exp.hako :as hako])
+  (:import (com.s_exp.hako Reader Writer)
+           (java.io DataInput DataOutput)
+           (java.lang.foreign MemorySegment ValueLayout)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^ThreadLocal tl-writer
+  (proxy [ThreadLocal] []
+    (initialValue [] (hako/writer 4096))))
+
+(def ^:private ^ThreadLocal tl-reader
+  (proxy [ThreadLocal] []
+    (initialValue [] (hako/reader (byte-array 0)))))
+
+(def ^:private ^ThreadLocal tl-scratch
+  (proxy [ThreadLocal] []
+    (initialValue [] (byte-array 4096))))
+
+(defn- ^bytes ensure-scratch [^long n]
+  (let [buf ^bytes (.get tl-scratch)]
+    (if (>= (alength buf) n)
+      buf
+      (let [grown (byte-array (max n (* 2 (alength buf))))]
+        (.set tl-scratch grown)
+        grown))))
+
+(defn freeze-to-out!
+  "Encode `v` with hako and write `<u32 length><payload>` to `out`."
+  [^DataOutput out v]
+  (let [wr ^Writer (.get tl-writer)
+        seg (hako/encode-into! wr v)
+        n (.byteSize seg)
+        _ (when (> n Integer/MAX_VALUE)
+            (throw (IllegalStateException.
+                    (str "hako-codec: payload exceeds Integer/MAX_VALUE: " n))))
+        buf (ensure-scratch n)]
+    (MemorySegment/copy seg ValueLayout/JAVA_BYTE 0 buf 0 n)
+    (.writeInt out (int n))
+    (.write out buf 0 (int n))))
+
+(defn thaw-from-in!
+  "Read a `<u32 length><payload>` frame from `in` and hako-decode it."
+  [^DataInput in]
+  (let [n (.readInt in)
+        buf ^bytes (ensure-scratch n)
+        _ (.readFully in buf 0 n)
+        rd ^Reader (.get tl-reader)
+        seg (MemorySegment/ofArray buf)]
+    (hako/decode-into! rd (.asSlice ^MemorySegment seg 0 n) {:cache-idents true})))
+
+(defn freeze
+  "Encode `v` to a fresh byte[]. Convenience mirror of nippy/freeze."
+  ^bytes [v]
+  (hako/encode v))
+
+(defn thaw
+  "Decode a hako-encoded byte[]. Convenience mirror of nippy/thaw."
+  [^bytes bs]
+  (hako/decode bs {:cache-idents true}))

--- a/src/datalevin/hako_codec.clj
+++ b/src/datalevin/hako_codec.clj
@@ -8,11 +8,16 @@
   without refactoring callers to `MemorySegment`.
 
   Wire format per call: `<u32 length LE><hako-encoded payload>`.
-  Length-prefix lets multiple values interleave in the same stream."
+  Length-prefix lets multiple values interleave in the same stream.
+
+  Phase 2 additions: `put-data-into-buffer!` bypasses the byte[]
+  bounce for LMDB writes — hako's arena-backed MemorySegment gets
+  copied directly into the caller's ByteBuffer, no heap intermediate."
   (:require [s-exp.hako :as hako])
   (:import (com.s_exp.hako Reader Writer)
            (java.io DataInput DataOutput)
-           (java.lang.foreign MemorySegment ValueLayout)))
+           (java.lang.foreign MemorySegment ValueLayout)
+           (java.nio ByteBuffer)))
 
 (set! *warn-on-reflection* true)
 
@@ -69,3 +74,57 @@
   "Decode a hako-encoded byte[]. Convenience mirror of nippy/thaw."
   [^bytes bs]
   (hako/decode bs {:cache-idents true}))
+
+(defn fast-freeze
+  "byte[]-returning encode via the thread-local reusable Writer.
+  Amortizes arena setup; copies segment → byte[] on the way out."
+  ^bytes [v]
+  (let [wr ^Writer (.get tl-writer)
+        seg (hako/encode-into! wr v)
+        n (.byteSize seg)
+        _ (when (> n Integer/MAX_VALUE)
+            (throw (IllegalStateException.
+                    (str "hako-codec: payload exceeds Integer/MAX_VALUE: " n))))
+        arr (byte-array n)]
+    (MemorySegment/copy seg ValueLayout/JAVA_BYTE 0 arr 0 n)
+    arr))
+
+(defn fast-thaw
+  "Decode via the thread-local reusable Reader."
+  [^bytes bs]
+  (let [rd ^Reader (.get tl-reader)
+        seg (MemorySegment/ofArray bs)]
+    (hako/decode-into! rd seg {:cache-idents true})))
+
+;; Phase 2: direct-ByteBuffer paths — skip the byte[] bounce.
+
+(defn put-data-into-buffer!
+  "Encode `v` with hako's reusable Writer, then copy segment bytes
+  directly into `bb` at its current position. Advances `bb.position`
+  by the byte count written. Skips the byte[] intermediate that
+  `serialize` + `.put(bb, bs)` allocates. Returns the byte count."
+  [^ByteBuffer bb v]
+  (let [wr ^Writer (.get tl-writer)
+        seg (hako/encode-into! wr v)
+        n (.byteSize seg)
+        _ (when (> n Integer/MAX_VALUE)
+            (throw (IllegalStateException.
+                    (str "hako-codec: payload exceeds Integer/MAX_VALUE: " n))))
+        src-bb (.asByteBuffer seg)]
+    (.put bb src-bb)
+    (int n)))
+
+(defn get-data-from-buffer!
+  "Decode `n` bytes from `bb`'s current position via the reusable
+  Reader. Wraps the ByteBuffer region as a MemorySegment slice —
+  zero heap copy for the wrap step. Advances `bb.position` by n."
+  [^ByteBuffer bb ^long n]
+  (let [rd ^Reader (.get tl-reader)
+        start (.position bb)
+        seg (if (.hasArray bb)
+              (.asSlice (MemorySegment/ofArray ^bytes (.array bb))
+                        (+ (.arrayOffset bb) start) n)
+              (.asSlice (MemorySegment/ofBuffer bb) 0 n))
+        v (hako/decode-into! rd seg {:cache-idents true})]
+    (.position bb (+ start (int n)))
+    v))

--- a/src/datalevin/hako_codec.clj
+++ b/src/datalevin/hako_codec.clj
@@ -7,19 +7,42 @@
   forces an intermediate `byte[]` copy — genuinely unavoidable
   without refactoring callers to `MemorySegment`.
 
-  Wire format per call: `<u32 length LE><hako-encoded payload>`.
+  Wire format per call:
+    `<u32 compressed-length LE><zstd frame containing hako-encoded payload>`.
   Length-prefix lets multiple values interleave in the same stream.
+  Zstd compression matches nippy's default `freeze` behavior — dump
+  files stay compact. Hot-path LMDB records use uncompressed
+  `put-data-into-buffer!` (below).
 
   Phase 2 additions: `put-data-into-buffer!` bypasses the byte[]
   bounce for LMDB writes — hako's arena-backed MemorySegment gets
-  copied directly into the caller's ByteBuffer, no heap intermediate."
+  copied directly into the caller's ByteBuffer, no heap intermediate.
+
+  Thread-local cleanup: long-running hosts with pooled threads have
+  nothing to do — the ThreadLocals live for the thread's lifetime.
+  Short-lived-thread hosts should call `close-thread-locals!` at the
+  end of each thread's work to release the confined `Arena` inside
+  the Writer and drop the scratch buffers."
   (:require [s-exp.hako :as hako])
-  (:import (com.s_exp.hako Reader Writer)
+  (:import (com.github.luben.zstd Zstd)
+           (com.s_exp.hako Reader Writer)
            (java.io DataInput DataOutput)
            (java.lang.foreign MemorySegment ValueLayout)
            (java.nio ByteBuffer)))
 
 (set! *warn-on-reflection* true)
+
+;; Cap the scratch buffer so a one-off huge dump doesn't pin the
+;; ThreadLocal at that size for the JVM lifetime. Above this, allocate
+;; a one-shot byte[] that the GC can reclaim.
+(def ^:private ^:const scratch-max-bytes (* 1024 1024))
+
+(def ^:private ^:const zstd-level 3)
+
+;; Hard cap on `thaw-from-in!` frame size — protects against a hostile
+;; or corrupt length prefix triggering an OOM allocation. 256 MiB is
+;; well above any realistic dump entry.
+(def ^:private ^:const max-frame-bytes (* 256 1024 1024))
 
 (def ^:private ^ThreadLocal tl-writer
   (proxy [ThreadLocal] []
@@ -33,16 +56,47 @@
   (proxy [ThreadLocal] []
     (initialValue [] (byte-array 4096))))
 
+(def ^:private ^ThreadLocal tl-compressed-scratch
+  (proxy [ThreadLocal] []
+    (initialValue [] (byte-array 4096))))
+
 (defn- ^bytes ensure-scratch [^long n]
   (let [buf ^bytes (.get tl-scratch)]
-    (if (>= (alength buf) n)
-      buf
+    (cond
+      (>= (alength buf) n) buf
+      ;; Above the cap, return a one-shot buffer without storing it.
+      (> n scratch-max-bytes) (byte-array n)
+      :else
       (let [grown (byte-array (max n (* 2 (alength buf))))]
         (.set tl-scratch grown)
         grown))))
 
+(defn- ^bytes ensure-compressed-scratch [^long n]
+  (let [buf ^bytes (.get tl-compressed-scratch)]
+    (cond
+      (>= (alength buf) n) buf
+      (> n scratch-max-bytes) (byte-array n)
+      :else
+      (let [grown (byte-array (max n (* 2 (alength buf))))]
+        (.set tl-compressed-scratch grown)
+        grown))))
+
+(defn close-thread-locals!
+  "Release the current thread's Writer arena and drop scratch buffers.
+  Call at the end of a short-lived thread's work — long-running pooled
+  threads don't need this. Idempotent; safe to call more than once."
+  []
+  (when-let [wr ^Writer (.get tl-writer)]
+    (.close wr))
+  (.remove tl-writer)
+  (.remove tl-reader)
+  (.remove tl-scratch)
+  (.remove tl-compressed-scratch))
+
 (defn freeze-to-out!
-  "Encode `v` with hako and write `<u32 length><payload>` to `out`."
+  "Encode `v` with hako, zstd-compress the payload, and write
+  `<u32 compressed-length><zstd frame>` to `out`. Compression matches
+  nippy's default `freeze` behavior — dump files stay compact."
   [^DataOutput out v]
   (let [wr ^Writer (.get tl-writer)
         seg (hako/encode-into! wr v)
@@ -50,20 +104,56 @@
         _ (when (> n Integer/MAX_VALUE)
             (throw (IllegalStateException.
                     (str "hako-codec: payload exceeds Integer/MAX_VALUE: " n))))
-        buf (ensure-scratch n)]
-    (MemorySegment/copy seg ValueLayout/JAVA_BYTE 0 buf 0 n)
-    (.writeInt out (int n))
-    (.write out buf 0 (int n))))
+        raw ^bytes (ensure-scratch n)
+        _ (MemorySegment/copy seg ValueLayout/JAVA_BYTE 0 raw 0 n)
+        bound (Zstd/compressBound n)
+        _ (when (> bound Integer/MAX_VALUE)
+            (throw (IllegalStateException.
+                    (str "hako-codec: compress bound exceeds Integer/MAX_VALUE: "
+                         bound))))
+        cbuf ^bytes (ensure-compressed-scratch bound)
+        cn (Zstd/compressByteArray cbuf 0 (int bound)
+                                   raw 0 (int n)
+                                   (int zstd-level))
+        _ (when (Zstd/isError cn)
+            (throw (IllegalStateException.
+                    (str "hako-codec: zstd compress error: "
+                         (Zstd/getErrorName cn)))))]
+    (.writeInt out (int cn))
+    (.write out cbuf 0 (int cn))))
 
 (defn thaw-from-in!
-  "Read a `<u32 length><payload>` frame from `in` and hako-decode it."
+  "Read a `<u32 compressed-length><zstd frame>` from `in`, decompress,
+  and hako-decode."
   [^DataInput in]
-  (let [n (.readInt in)
-        buf ^bytes (ensure-scratch n)
-        _ (.readFully in buf 0 n)
+  (let [cn (.readInt in)
+        _ (when (or (neg? cn) (> cn max-frame-bytes))
+            (throw (IllegalStateException.
+                    (str "hako-codec: frame length out of range: " cn))))
+        compressed ^bytes (ensure-compressed-scratch cn)
+        _ (.readFully in compressed 0 cn)
+        orig-size (Zstd/getFrameContentSize compressed)
+        _ (when (or (neg? orig-size)
+                    (> orig-size Integer/MAX_VALUE)
+                    (> orig-size max-frame-bytes))
+            (throw (IllegalStateException.
+                    (str "hako-codec: zstd frame content size out of range: "
+                         orig-size))))
+        raw ^bytes (ensure-scratch orig-size)
+        actual (Zstd/decompressByteArray raw 0 (int orig-size)
+                                         compressed 0 cn)
+        _ (when (Zstd/isError actual)
+            (throw (IllegalStateException.
+                    (str "hako-codec: zstd decompress error: "
+                         (Zstd/getErrorName actual)))))
+        _ (when (not= actual orig-size)
+            (throw (IllegalStateException.
+                    (str "hako-codec: zstd decompressed "
+                         actual " bytes, expected " orig-size))))
         rd ^Reader (.get tl-reader)
-        seg (MemorySegment/ofArray buf)]
-    (hako/decode-into! rd (.asSlice ^MemorySegment seg 0 n) {:cache-idents true})))
+        seg (MemorySegment/ofArray raw)]
+    (hako/decode-into! rd (.asSlice ^MemorySegment seg 0 orig-size)
+                       {:cache-idents true})))
 
 (defn freeze
   "Encode `v` to a fresh byte[]. Signature-compatible with the
@@ -101,20 +191,13 @@
 ;; Phase 2: direct-ByteBuffer paths — skip the byte[] bounce.
 
 (defn put-data-into-buffer!
-  "Encode `v` with hako's reusable Writer, then copy segment bytes
-  directly into `bb` at its current position. Advances `bb.position`
-  by the byte count written. Skips the byte[] intermediate that
-  `serialize` + `.put(bb, bs)` allocates. Returns the byte count."
+  "Encode `v` with hako's reusable Writer, copying bytes directly into
+  `bb` at its current position. Advances `bb.position` by the byte
+  count written and returns it. Uses `hako/encode-into-buffer!` —
+  skips both the MemorySegment slice wrapper and the `.asByteBuffer`
+  view that the earlier two-step form allocated per call."
   [^ByteBuffer bb v]
-  (let [wr ^Writer (.get tl-writer)
-        seg (hako/encode-into! wr v)
-        n (.byteSize seg)
-        _ (when (> n Integer/MAX_VALUE)
-            (throw (IllegalStateException.
-                    (str "hako-codec: payload exceeds Integer/MAX_VALUE: " n))))
-        src-bb (.asByteBuffer seg)]
-    (.put bb src-bb)
-    (int n)))
+  (hako/encode-into-buffer! ^Writer (.get tl-writer) bb v))
 
 (defn get-data-from-buffer!
   "Decode `n` bytes from `bb`'s current position via the reusable

--- a/src/datalevin/interpret.clj
+++ b/src/datalevin/interpret.clj
@@ -568,7 +568,7 @@
   `(def ~fn-name (inter-fn ~args ~@body)))
 
 (hext/register-user-tag!
- 0x10000009                             ; private range, subtag 9 = inter-fn
+ 9                                      ; subtag 9 = inter-fn (wire id 0x10000009)
  AFn
  (fn write-inter-fn [^com.s_exp.hako.Writer w ^AFn x]
    (if (inter-fn? x)

--- a/src/datalevin/interpret.clj
+++ b/src/datalevin/interpret.clj
@@ -16,7 +16,7 @@
    [clojure.pprint :as p]
    [clojure.java.io :as io]
    [sci.core :as sci]
-   [taoensso.nippy :as nippy]
+   [s-exp.hako.ext :as hext]
    [datalevin.query-util :as qu]
    [datalevin.util :as u]
    [datalevin.core]
@@ -51,12 +51,12 @@
 (defn ^:no-doc available-map [ns var-map pred]
   (let [sci-ns (sci/create-ns ns)]
     (reduce
-      (fn [m [k v]]
-        (assoc m k (sci/new-var (symbol v) v (assoc (meta v)
-                                                    :sci.impl/built-in true
-                                                    :ns sci-ns))))
-      {}
-      (select-keys var-map (keep (fn [[k v]] (when (pred v) k)) var-map)))))
+     (fn [m [k v]]
+       (assoc m k (sci/new-var (symbol v) v (assoc (meta v)
+                                                   :sci.impl/built-in true
+                                                   :ns sci-ns))))
+     {}
+     (select-keys var-map (keep (fn [[k v]] (when (pred v) k)) var-map)))))
 
 (defn ^:no-doc user-facing-map [ns var-map]
   (available-map ns var-map user-facing?))
@@ -66,17 +66,17 @@
 
 (defn- user-facing-vars []
   (reduce
-    (fn [m ns]
-      (assoc m ns (user-facing-map ns (ns-publics ns))))
-    {}
-    user-facing-ns))
+   (fn [m ns]
+     (assoc m ns (user-facing-map ns (ns-publics ns))))
+   {}
+   user-facing-ns))
 
 (defn- additional-vars []
   (reduce
-    (fn [m ns]
-      (assoc m ns (additional-map ns (ns-publics ns))))
-    {}
-    additional-ns))
+   (fn [m ns]
+     (assoc m ns (additional-map ns (ns-publics ns))))
+   {}
+   additional-ns))
 
 (defn ^:no-doc resolve-var [s]
   (when (symbol? s)
@@ -488,20 +488,20 @@
   (let [sci-ns (sci/create-ns ns-sym)]
     [ns-sym
      (reduce
-       (fn [m sym]
-         (let [var-sym (symbol (name sym))
-               v       (or (resolve-public-host-var sym)
-                           (u/raise
-                             "Cannot resolve host var for inter-fn " sym
-                             {:type   :datalevin/unresolved-inter-fn-host-var
-                              :symbol sym}))]
-           (assoc m var-sym
-                  (sci/new-var (symbol v) v
-                               (assoc (meta v)
-                                      :sci.impl/built-in true
-                                      :ns sci-ns)))))
-       {}
-       syms)]))
+      (fn [m sym]
+        (let [var-sym (symbol (name sym))
+              v       (or (resolve-public-host-var sym)
+                          (u/raise
+                           "Cannot resolve host var for inter-fn " sym
+                           {:type   :datalevin/unresolved-inter-fn-host-var
+                            :symbol sym}))]
+          (assoc m var-sym
+                 (sci/new-var (symbol v) v
+                              (assoc (meta v)
+                                     :sci.impl/built-in true
+                                     :ns sci-ns)))))
+      {}
+      syms)]))
 
 (defn- host-var-namespaces
   [src]
@@ -567,16 +567,15 @@
   [fn-name args & body]
   `(def ~fn-name (inter-fn ~args ~@body)))
 
-(nippy/extend-freeze AFn :datalevin/inter-fn
-    [^AFn x ^DataOutput out]
-  (if (inter-fn? x)
-    (nippy/freeze-to-out! out (:source (meta x)))
-    (u/raise "Can only freeze an inter-fn" {:x x})))
-
-(nippy/extend-thaw :datalevin/inter-fn
-    [^DataInput in]
-  (let [src (nippy/thaw-from-in! in)]
-    (source->inter-fn src)))
+(hext/register-user-tag!
+ 0x10000009                             ; private range, subtag 9 = inter-fn
+ AFn
+ (fn write-inter-fn [^com.s_exp.hako.Writer w ^AFn x]
+   (if (inter-fn? x)
+     (.writeAny w (:source (meta x)))
+     (u/raise "Can only freeze an inter-fn" {:x x})))
+ (fn read-inter-fn [^com.s_exp.hako.Reader r]
+   (source->inter-fn (.readAny r))))
 
 (defmethod print-method :datalevin/inter-fn [f, ^Writer w]
   (.write w "#datalevin/inter-fn ")

--- a/src/datalevin/lmdb.clj
+++ b/src/datalevin/lmdb.clj
@@ -15,7 +15,7 @@
    [clojure.edn :as edn]
    [clojure.string :as s]
    [clojure.pprint :as p]
-   [taoensso.nippy :as nippy]
+   [datalevin.hako-codec :as codec]
    [datalevin.async :as a]
    [datalevin.bits :as b]
    [datalevin.util :as u]
@@ -256,9 +256,9 @@
    (p/pprint (set (list-dbis lmdb))))
   ([lmdb data-output]
    (if data-output
-     (nippy/freeze-to-out!
-       data-output
-       (set (list-dbis lmdb)))
+     (codec/freeze-to-out!
+      data-output
+      (set (list-dbis lmdb)))
      (dump-dbis-list lmdb))))
 
 ;; We have consolidated bindings to JavaCPP
@@ -296,7 +296,7 @@
      (p/pprint [(b/encode-base64 k) (b/encode-base64 v)])))
   ([lmdb dbi data-output]
    (if data-output
-     (nippy/freeze-to-out! data-output (nippy-dbi lmdb dbi))
+     (codec/freeze-to-out! data-output (nippy-dbi lmdb dbi))
      (dump-dbi lmdb dbi))))
 
 (defn dump-dbi-section
@@ -314,10 +314,10 @@
    (doseq [dbi (set (list-dbis lmdb))] (dump-dbi lmdb dbi)))
   ([lmdb data-output]
    (if data-output
-     (nippy/freeze-to-out!
-       data-output
-       (conj (for [dbi (set (list-dbis lmdb))] (nippy-dbi lmdb dbi))
-             (nippy-dbi lmdb c/kv-info)))
+     (codec/freeze-to-out!
+      data-output
+      (conj (for [dbi (set (list-dbis lmdb))] (nippy-dbi lmdb dbi))
+            (nippy-dbi lmdb c/kv-info)))
      (dump-all lmdb))))
 
 (defn- load-kv [dbi [k v]]
@@ -333,7 +333,7 @@
 (defn load-dbi
   ([lmdb dbi in nippy?]
    (if nippy?
-     (let [[_ kvs] (nippy/thaw-from-in! in)]
+     (let [[_ kvs] (codec/thaw-from-in! in)]
        (open-dbi lmdb dbi)
        (transact-kv lmdb (map #(load-kv dbi %) kvs)))
      (load-dbi lmdb dbi in)))
@@ -359,7 +359,7 @@
 (defn load-all
   ([lmdb in nippy?]
    (if nippy?
-     (doseq [[{:keys [dbi]} kvs] (nippy/thaw-from-in! in)]
+     (doseq [[{:keys [dbi]} kvs] (codec/thaw-from-in! in)]
        (open-dbi lmdb dbi)
        (transact-kv lmdb (map #(load-kv dbi %) kvs)))
      (load-all lmdb in)))
@@ -392,7 +392,7 @@
                            (mapcat load-dbi)))))
 
 (defn clear [lmdb]
-  (doseq [dbi (set (list-dbis lmdb)) ] (clear-dbi lmdb dbi)))
+  (doseq [dbi (set (list-dbis lmdb))] (clear-dbi lmdb dbi)))
 
 (defn dump
   [db ^String dumpfile]
@@ -413,7 +413,7 @@
   (try
     (let [bk    (when (:backup? opts)
                   (u/tmp-dir
-                    (str "dtlv-re-index-" (System/currentTimeMillis))))
+                   (str "dtlv-re-index-" (System/currentTimeMillis))))
           d     (env-dir db)
           dfile (str d u/+separator+ "kv-dump")]
       (when bk (copy db bk true))
@@ -548,12 +548,12 @@
   [db]
   (* ^long (:psize (stat db))
      ^long (reduce
-             (fn [^long pages dbi]
-               (+ pages (let [m (stat db dbi)]
-               (+ ^long (:branch-pages m)
-                              ^long (:leaf-pages m)
-                              ^long (:overflow-pages m)))))
-             0 (list-dbis db))))
+            (fn [^long pages dbi]
+              (+ pages (let [m (stat db dbi)]
+                         (+ ^long (:branch-pages m)
+                            ^long (:leaf-pages m)
+                            ^long (:overflow-pages m)))))
+            0 (list-dbis db))))
 
 (defmacro with-transaction-kv
   "Evaluate body within the context of a single new read/write transaction,
@@ -586,43 +586,43 @@
              opened?#   (volatile! false)
              condition# (fn [~'e] (and (resized? ~'e) (not writing#)))]
          (u/repeat-try-catch
-             ~c/+in-tx-overflow-times+
-             condition#
-             (try
-               (vreset! opened?# false)
-               (let [watchdog# (volatile! nil)
-                     res#      (try
-                                 (vreset! watchdog#
-                                          (start-explicit-transaction-watchdog!
-                                           tx-timeout-ms#))
-                                 (let [res# (let [~db (if writing#
-                                                        orig-db#
-                                                        (let [db# (open-transact-kv
-                                                                   orig-db#)]
-                                                          (vreset! opened?# true)
-                                                          db#))]
-                                              (u/repeat-try-catch
-                                                  ~c/+in-tx-overflow-times+
-                                                  condition#
-                                                ~@body))]
-                                   (cancel-explicit-transaction-watchdog!
-                                    @watchdog#)
-                                   (assert-explicit-transaction-live!
-                                    @watchdog#)
-                                   res#)
-                                 (catch Throwable t#
-                                   (throw-explicit-transaction-failure!
-                                    @watchdog# t#))
-                                 (finally
-                                   (cancel-explicit-transaction-watchdog!
-                                    @watchdog#)))]
-                 (when (and (not writing#) @opened?#)
-                   (close-transact-kv orig-db#))
-                 res#)
-             (catch Throwable t#
-               (when (and (not writing#) @opened?#)
-                 (abort-open-transaction-kv! orig-db# t#))
-               (throw t#))))))))
+          ~c/+in-tx-overflow-times+
+          condition#
+          (try
+            (vreset! opened?# false)
+            (let [watchdog# (volatile! nil)
+                  res#      (try
+                              (vreset! watchdog#
+                                       (start-explicit-transaction-watchdog!
+                                        tx-timeout-ms#))
+                              (let [res# (let [~db (if writing#
+                                                     orig-db#
+                                                     (let [db# (open-transact-kv
+                                                                orig-db#)]
+                                                       (vreset! opened?# true)
+                                                       db#))]
+                                           (u/repeat-try-catch
+                                            ~c/+in-tx-overflow-times+
+                                            condition#
+                                            ~@body))]
+                                (cancel-explicit-transaction-watchdog!
+                                 @watchdog#)
+                                (assert-explicit-transaction-live!
+                                 @watchdog#)
+                                res#)
+                              (catch Throwable t#
+                                (throw-explicit-transaction-failure!
+                                 @watchdog# t#))
+                              (finally
+                                (cancel-explicit-transaction-watchdog!
+                                 @watchdog#)))]
+              (when (and (not writing#) @opened?#)
+                (close-transact-kv orig-db#))
+              res#)
+            (catch Throwable t#
+              (when (and (not writing#) @opened?#)
+                (abort-open-transaction-kv! orig-db# t#))
+              (throw t#))))))))
 
 ;; for shutting down various executors when the last LMDB exits
 (defonce lmdb-dirs (atom #{}))

--- a/src/datalevin/migrate.clj
+++ b/src/datalevin/migrate.clj
@@ -13,7 +13,7 @@
    [clojure.java.io :as io]
    [clojure.java.shell :as sh]
    [clojure.edn :as edn]
-   [taoensso.nippy :as nippy]
+   [datalevin.hako-codec :as codec]
    [datalevin.datom :as dd]
    [datalevin.lmdb :as l]
    [datalevin.interface :as if]
@@ -32,8 +32,8 @@
 (defn- jar-url
   [version]
   (format
-    "https://github.com/juji-io/datalevin/releases/download/%s/datalevin-%s-standalone.jar"
-    version version))
+   "https://github.com/juji-io/datalevin/releases/download/%s/datalevin-%s-standalone.jar"
+   version version))
 
 (defn ensure-jar
   [major minor patch]
@@ -200,7 +200,7 @@
   (with-open [in (DataInputStream. (BufferedInputStream. stream))]
     (let [{:keys [format opts schema source-count kv-dbis kv-source-count]
            :as   header}
-          (nippy/thaw-from-in! in)]
+          (codec/thaw-from-in! in)]
       (when-not (and (= mixed-stream-format format)
                      (map? opts)
                      (map? schema)
@@ -211,15 +211,15 @@
       (let [db (volatile! (@empty-db dir schema opts))]
         (try
           (let [end-info (loop []
-                           (let [batch (nippy/thaw-from-in! in)]
+                           (let [batch (codec/thaw-from-in! in)]
                              (if (map? batch)
                                batch
                                (do
                                  (vreset!
-                                   db
-                                   (@fill-db
-                                     @db
-                                     (map #(apply dd/datom %) batch)))
+                                  db
+                                  (@fill-db
+                                   @db
+                                   (map #(apply dd/datom %) batch)))
                                  (recur)))))]
             (when-not (= {:frame       :datalog-end
                           :datom-count source-count}
@@ -239,11 +239,11 @@
                 (let [kv     (l/open-kv dir)
                       result (try
                                (merge
-                                 {:source-count source-count
-                                  :loaded-count loaded-count
-                                  :dump-count   (:datom-count end-info)}
-                                 (load-kv-sections kv in kv-dbis
-                                                   kv-source-count))
+                                {:source-count source-count
+                                 :loaded-count loaded-count
+                                 :dump-count   (:datom-count end-info)}
+                                (load-kv-sections kv in kv-dbis
+                                                  kv-source-count))
                                (finally
                                  (if/close-kv kv)))]
                   (cleanup-non-wal-artifacts! dir opts)
@@ -254,20 +254,20 @@
 
 (defn- load-kv-dbi
   [kv in {:keys [dbi entries opts] :as expected}]
-  (let [start (nippy/thaw-from-in! in)]
+  (let [start (codec/thaw-from-in! in)]
     (when-not (= (assoc expected :frame :dbi) start)
       (raise "Invalid KV migration DBI header"
              {:expected expected :header start}))
     (if opts (if/open-dbi kv dbi opts) (if/open-dbi kv dbi))
     (if/clear-dbi kv dbi)
     (loop [loaded 0]
-      (let [frame (nippy/thaw-from-in! in)]
+      (let [frame (codec/thaw-from-in! in)]
         (cond
           (vector? frame)
           (do
             (if/transact-kv
-              kv
-              (map (fn [[k v]] (l/kv-tx :put dbi k v :raw :raw)) frame))
+             kv
+             (map (fn [[k v]] (l/kv-tx :put dbi k v :raw :raw)) frame))
             (recur (+ loaded (count frame))))
 
           (= {:frame :dbi-end :dbi dbi :entry-count loaded} frame)
@@ -288,11 +288,11 @@
   [kv in dbis source-count]
   (let [loaded-count
         (reduce
-          (fn [total expected]
-            (+ (long total) (long (load-kv-dbi kv in expected))))
-          0
-          dbis)
-        end (nippy/thaw-from-in! in)]
+         (fn [total expected]
+           (+ (long total) (long (load-kv-dbi kv in expected))))
+         0
+         dbis)
+        end (codec/thaw-from-in! in)]
     (when-not (= {:frame :end :entry-count source-count} end)
       (raise "Invalid KV migration stream end" {:frame end}))
     {:kv-source-count source-count
@@ -303,13 +303,13 @@
   [dir stream]
   (with-open [in (DataInputStream. (BufferedInputStream. stream))]
     (let [{:keys [format opts dbis source-count] :as header}
-          (nippy/thaw-from-in! in)]
+          (codec/thaw-from-in! in)]
       (when-not (and (= kv-stream-format format)
                      (map? opts)
                      (valid-kv-dbis? dbis source-count))
         (raise "Invalid KV migration stream header" {:header header}))
       (let [opts (cond-> (dissoc opts :dir :temp? :inmemory?
-                                :max-val-size-changed?)
+                                 :max-val-size-changed?)
                    (:flags opts) (update :flags disj :inmemory))
             kv   (l/open-kv dir opts)
             result

--- a/src/datalevin/protocol.clj
+++ b/src/datalevin/protocol.clj
@@ -34,11 +34,11 @@
 
 (def transit-write-handlers
   {Datom           (transit/write-handler
-                     "datalevin/Datom"
-                     (fn [^Datom d] [(.-e d) (.-a d) (.-v d) (.-tx d)]))
+                    "datalevin/Datom"
+                    (fn [^Datom d] [(.-e d) (.-a d) (.-v d) (.-tx d)]))
    SpillableVector (transit/write-handler
-                     "datalevin/SpillableVector"
-                     (fn [v] (into [] v)))})
+                    "datalevin/SpillableVector"
+                    (fn [v] (into [] v)))})
 
 (declare write-transit-bytes)
 
@@ -128,9 +128,9 @@
   [^String s]
   (try
     (transit/read
-      (transit/reader
-        (ByteArrayInputStream. (.getBytes s "utf-8")) :json
-        {:handlers transit-read-handlers}))
+     (transit/reader
+      (ByteArrayInputStream. (.getBytes s "utf-8")) :json
+      {:handlers transit-read-handlers}))
     (catch Exception e
       (u/raise "Unable to read transit:" e {:string s}))))
 
@@ -140,7 +140,7 @@
   (try
     (let [baos (ByteArrayOutputStream.)]
       (transit/write
-        (transit/writer baos :json {:handlers transit-write-handlers}) v)
+       (transit/writer baos :json {:handlers transit-write-handlers}) v)
       (.toString baos "utf-8"))
     (catch Exception e
       (u/raise "Unable to write transit:" e {:value v}))))
@@ -188,7 +188,7 @@
   "Write a message to a ByteBuffer. First byte is format, then four bytes
   length of the whole message (include header), followed by message value"
   ([bf msg]
-   (write-message-bf bf msg c/message-format-nippy nil))
+   (write-message-bf bf msg c/message-format-hako nil))
   ([bf msg fmt]
    (write-message-bf bf msg fmt nil))
   ([^ByteBuffer bf msg fmt wire-opts]
@@ -251,7 +251,7 @@
 (defn send-all
   "Send all data in buffer to channel, will block if channel is busy.
   Close the channel and raise exception if something is wrong"
-  [^SocketChannel ch ^ByteBuffer bf ]
+  [^SocketChannel ch ^ByteBuffer bf]
   (let [non-blocking? (not (.isBlocking ch))
         selector      (volatile! nil)]
     (try
@@ -292,7 +292,7 @@
   ([^SocketChannel ch ^ByteBuffer bf msg wire-opts]
    (locking bf
      (.clear bf)
-     (write-message-bf bf msg c/message-format-nippy wire-opts)
+     (write-message-bf bf msg c/message-format-hako wire-opts)
      (.flip bf)
      (send-all ch bf))))
 
@@ -313,7 +313,7 @@
                  read-bf   (if (< (.capacity read-bf) length)
                              (let [^ByteBuffer bf
                                    (ByteBuffer/allocateDirect
-                                     (* ^long c/+buffer-grow-factor+ length))]
+                                    (* ^long c/+buffer-grow-factor+ length))]
                                (.rewind read-bf)
                                (bf/buffer-transfer read-bf bf)
                                bf)

--- a/src/datalevin/protocol.clj
+++ b/src/datalevin/protocol.clj
@@ -76,7 +76,9 @@
 
 (defn- serialize-value
   ^bytes [fmt msg]
-  (case (short fmt)
+  ;; `short` alone would sign-extend a byte >= 0x80; go through
+  ;; fmt-code which masks the flag bits and gives an unsigned code.
+  (case (int (fmt-code fmt))
     1 (write-transit-bytes msg)
     2 (b/serialize msg)
     (u/raise "Unknown wire message format"
@@ -174,13 +176,17 @@
 
 (defn- write-value-bf
   [bf fmt msg]
-  (case (short fmt)
+  ;; `short` alone would sign-extend a byte >= 0x80; go through
+  ;; fmt-code which masks the flag bits and gives an unsigned code.
+  (case (int (fmt-code fmt))
     1 (write-transit-bf bf msg)
     2 (write-nippy-bf bf msg)))
 
 (defn- read-value-bf
   [bf fmt]
-  (case (short fmt)
+  ;; `short` alone would sign-extend a byte >= 0x80; go through
+  ;; fmt-code which masks the flag bits and gives an unsigned code.
+  (case (int (fmt-code fmt))
     1 (read-transit-bf bf)
     2 (read-nippy-bf bf)))
 

--- a/src/datalevin/search.clj
+++ b/src/datalevin/search.clj
@@ -21,7 +21,7 @@
    [datalevin.remote :as r]
    [datalevin.constants :as c]
    [datalevin.bits :as b]
-   [taoensso.nippy :as nippy]
+   [datalevin.hako-codec :as codec]
    [clojure.set :as set]
    [clojure.string :as s])
   (:import
@@ -167,14 +167,14 @@
 
 (defmethod print-method Candidate [^Candidate c, ^Writer w]
   (.write w (pr-str
-              (let [hn? (has-next? c)]
-                (cond-> {:tid (.-tid c)
-                         :sl  (.-sl c)}
-                  hn?  ((fn [m]
-                          (let [did (get-did c)]
-                            (merge m {:did did
-                                      :tf  (get-tf c did)}))))
-                  true (merge {:has-next? hn?}))))))
+             (let [hn? (has-next? c)]
+               (cond-> {:tid (.-tid c)
+                        :sl  (.-sl c)}
+                 hn?  ((fn [m]
+                         (let [did (get-did c)]
+                           (merge m {:did did
+                                     :tf  (get-tf c did)}))))
+                 true (merge {:has-next? hn?}))))))
 
 (defn- find-pivot
   [^IntDoubleHashMap mxs tao-1 minimal-score
@@ -256,35 +256,35 @@
         z        (inc (- ^long n ^long tao))
         union-bm (prefix-union-bm rbms z)]
     (candidate-array
-      (dotimes [i (count tids)]
-        (let [tid  (nth tids i)
-              bm   (aget rbms i)
-              bm'  (doto (bitmap-provider->roaring bm)
-                     (.and ^RoaringBitmap bbm)
-                     (.and ^RoaringBitmap union-bm)
-                     (.andNot result))
-              iter (.getIntIterator ^RoaringBitmap bm')]
-          (when (.hasNext ^PeekableIntIterator iter)
-            (.add lst (Candidate. tid (nth rsls i) iter))))))))
+     (dotimes [i (count tids)]
+       (let [tid  (nth tids i)
+             bm   (aget rbms i)
+             bm'  (doto (bitmap-provider->roaring bm)
+                    (.and ^RoaringBitmap bbm)
+                    (.and ^RoaringBitmap union-bm)
+                    (.andNot result))
+             iter (.getIntIterator ^RoaringBitmap bm')]
+         (when (.hasNext ^PeekableIntIterator iter)
+           (.add lst (Candidate. tid (nth rsls i) iter))))))))
 
 (defn- next-candidates
   [did ^"[Ldatalevin.search.Candidate;" candidates]
   (let [did+1 (inc ^int did)]
     (candidate-array
-      (dotimes [i (alength candidates)]
-        (let [candidate (aget candidates i)]
-          (skip-before candidate did+1)
-          (when (has-next? candidate) (.add lst candidate)))))))
+     (dotimes [i (alength candidates)]
+       (let [candidate (aget candidates i)]
+         (skip-before candidate did+1)
+         (when (has-next? candidate) (.add lst candidate)))))))
 
 (defn- skip-candidates
   [pivot pivot-did ^"[Ldatalevin.search.Candidate;" candidates]
   (candidate-array
-    (dotimes [i (alength candidates)]
-      (let [candidate (aget candidates i)]
-        (if (< i ^long pivot)
-          (do (skip-before candidate pivot-did)
-              (when (has-next? candidate) (.add lst candidate)))
-          (.add lst candidate))))))
+   (dotimes [i (alength candidates)]
+     (let [candidate (aget candidates i)]
+       (if (< i ^long pivot)
+         (do (skip-before candidate pivot-did)
+             (when (has-next? candidate) (.add lst candidate)))
+         (.add lst candidate))))))
 
 (defn- current-threshold
   [^PriorityQueue pq]
@@ -365,35 +365,35 @@
                   ntid       (.-tid ^Positions next-poss)
                   ndist      (- npos cpos)]
               (cond+
-                (or (< max-dist ndist) (= ctid ntid))
-                (let [next-span (Span. (FastList.))]
-                  (.add spans cur-span)
-                  (recur next-poss next-span))
-                :let [found (find-term cur-span ntid)]
-                found
-                (let [[cur-span next-span]
-                      (if (< ndist (- ^long (get-next-pos cur-span found)
-                                      ^long (get-ith-pos cur-span found)))
-                        (split cur-span found)
-                        [cur-span (Span. (FastList.))])]
-                  (.add spans cur-span)
-                  (recur next-poss next-span))
-                :else
-                (recur next-poss cur-span)))))))
+               (or (< max-dist ndist) (= ctid ntid))
+               (let [next-span (Span. (FastList.))]
+                 (.add spans cur-span)
+                 (recur next-poss next-span))
+               :let [found (find-term cur-span ntid)]
+               found
+               (let [[cur-span next-span]
+                     (if (< ndist (- ^long (get-next-pos cur-span found)
+                                     ^long (get-ith-pos cur-span found)))
+                       (split cur-span found)
+                       [cur-span (Span. (FastList.))])]
+                 (.add spans cur-span)
+                 (recur next-poss next-span))
+               :else
+               (recur next-poss cur-span)))))))
     spans))
 
 (defn- proximity-score*
   [max-dist did spans ^IntDoubleHashMap wqs ^IntShortHashMap norms tid]
   (let [^double rc (reduce
-                     (fn [^double score span]
-                       (if (find-term span tid)
-                         (+ score
-                            (let [^long n (get-n span)
-                                  ^long w (get-width span max-dist)]
-                              (* (Math/pow (/ n w) 0.25)
-                                 (Math/pow n 0.3))))
-                         score))
-                     0.0 spans)]
+                    (fn [^double score span]
+                      (if (find-term span tid)
+                        (+ score
+                           (let [^long n (get-n span)
+                                 ^long w (get-width span max-dist)]
+                             (* (Math/pow (/ n w) 0.25)
+                                (Math/pow n 0.3))))
+                        score))
+                    0.0 spans)]
     (/ (* ^double (.get wqs tid) rc) (double (.get norms did)))))
 
 (defn- proximity-score
@@ -419,11 +419,11 @@
 (defn- match-phrase
   [did phrase engine tmid]
   (when-let [poss (reduce
-                    (fn [coll token]
-                      (if-let [ps (tid-positions engine did (tmid token))]
-                        (conj coll ps)
-                        (reduced nil)))
-                    [] phrase)]
+                   (fn [coll token]
+                     (if-let [ps (tid-positions engine did (tmid token))]
+                       (conj coll ps)
+                       (reduced nil)))
+                   [] phrase)]
     (let [pos-count        (count poss)
           ^ints first-poss (nth poss 0)]
       (loop [i 0]
@@ -476,27 +476,27 @@
            (first-candidates context result tao n)]
       (let [nc (alength candidates)]
         (cond+
-          (or (= nc 0) (< nc ^long tao)) :finish
+         (or (= nc 0) (< nc ^long tao)) :finish
 
-          :let [minimal-score ^double (current-threshold pq)]
+         :let [minimal-score ^double (current-threshold pq)]
 
-          (= nc 1)
-          (score-term context (aget candidates 0) norms minimal-score pq)
+         (= nc 1)
+         (score-term context (aget candidates 0) norms minimal-score pq)
 
-          :do (Arrays/sort candidates candidate-comp)
+         :do (Arrays/sort candidates candidate-comp)
 
-          :else
-          (let [[mxscore pivot did] (find-pivot mxs (dec ^long tao)
-                                                minimal-score
-                                                candidates)]
-            (if (= ^int did ^int (get-did (aget candidates 0)))
-              (let [score (score-pivot wqs mxs norms did minimal-score
-                                       mxscore tao n candidates)]
-                (when (and (not (identical? score :prune))
-                           (or no-phrases? (match-phrases context did)))
-                  (.insertWithOverflow ^PriorityQueue pq [score did]))
-                (recur (next-candidates did candidates)))
-              (recur (skip-candidates pivot did candidates)))))))))
+         :else
+         (let [[mxscore pivot did] (find-pivot mxs (dec ^long tao)
+                                               minimal-score
+                                               candidates)]
+           (if (= ^int did ^int (get-did (aget candidates 0)))
+             (let [score (score-pivot wqs mxs norms did minimal-score
+                                      mxscore tao n candidates)]
+               (when (and (not (identical? score :prune))
+                          (or no-phrases? (match-phrases context did)))
+                 (.insertWithOverflow ^PriorityQueue pq [score did]))
+               (recur (next-candidates did candidates)))
+             (recur (skip-candidates pivot did candidates)))))))))
 
 (defn- to-tokens
   [query-analyzer s]
@@ -520,8 +520,8 @@
   (if (and (seq exps) (operators op))
     (let [es (into []
                    (comp
-                     (map #(parse-query* query-analyzer %))
-                     (remove nil?))
+                    (map #(parse-query* query-analyzer %))
+                    (remove nil?))
                    exps)]
       (when (seq es) (vec (cons op es))))
     (raise "Invalid search query" {:op op})))
@@ -537,13 +537,13 @@
 (defn- required-clause-product
   [clauses clauses2]
   (persistent!
-    (reduce
-      (fn [acc clause]
-        (reduce (fn [acc clause2]
-                  (conj! acc (set/union clause clause2)))
-                acc clauses2))
-      (transient [])
-      clauses)))
+   (reduce
+    (fn [acc clause]
+      (reduce (fn [acc clause2]
+                (conj! acc (set/union clause clause2)))
+              acc clauses2))
+    (transient [])
+    clauses)))
 
 (defn- collect-required-clauses
   [expr pos? tokens]
@@ -562,28 +562,28 @@
         :and (if pos?
                (reduce (fn [clauses arg]
                          (required-clause-product
-                           clauses
-                           (collect-required-clauses arg true tokens)))
+                          clauses
+                          (collect-required-clauses arg true tokens)))
                        [#{}]
                        args)
                (persistent!
-                 (reduce (fn [acc arg]
-                           (reduce conj! acc
-                                   (collect-required-clauses arg false
-                                                             tokens)))
-                         (transient [])
-                         args)))
+                (reduce (fn [acc arg]
+                          (reduce conj! acc
+                                  (collect-required-clauses arg false
+                                                            tokens)))
+                        (transient [])
+                        args)))
         :or  (if pos?
                (persistent!
-                 (reduce (fn [acc arg]
-                           (reduce conj! acc
-                                   (collect-required-clauses arg true tokens)))
-                         (transient [])
-                         args))
+                (reduce (fn [acc arg]
+                          (reduce conj! acc
+                                  (collect-required-clauses arg true tokens)))
+                        (transient [])
+                        args))
                (reduce (fn [clauses arg]
                          (required-clause-product
-                           clauses
-                           (collect-required-clauses arg false tokens)))
+                          clauses
+                          (collect-required-clauses arg false tokens)))
                        [#{}]
                        args))))))
 
@@ -691,28 +691,28 @@
   (let [no-phrases? (empty? phrases)]
     (into []
           (comp
-            (map (fn [did]
-                   (when (or no-phrases? (match-phrases context did))
-                     [0.1 did])))
-            (remove nil?)
-            (take top))
+           (map (fn [did]
+                  (when (or no-phrases? (match-phrases context did))
+                    [0.1 did])))
+           (remove nil?)
+           (take top))
           bbm)))
 
 (defn- tiered-scoring
   [top scoring this proximity-expansion proximity-max-dist result n]
   (persistent!
-    (unreduced
-      (reduce
-        (fn [coll tao]
-          (let [to-get (- ^long top (count coll))]
-            (if (< 0 to-get)
-              (let [^PriorityQueue pq (priority-queue to-get)]
-                (scoring this pq tao to-get proximity-expansion
-                         proximity-max-dist)
-                (pouring coll pq result))
-              (reduced coll))))
-        (transient [])
-        (range n 0 -1)))))
+   (unreduced
+    (reduce
+     (fn [coll tao]
+       (let [to-get (- ^long top (count coll))]
+         (if (< 0 to-get)
+           (let [^PriorityQueue pq (priority-queue to-get)]
+             (scoring this pq tao to-get proximity-expansion
+                      proximity-max-dist)
+             (pouring coll pq result))
+           (reduced coll))))
+     (transient [])
+     (range n 0 -1)))))
 
 (def default-search-opts {:display             c/default-display
                           :top                 c/default-top
@@ -747,21 +747,21 @@
         limit?      (or (contains? opts :limit)
                         (contains? search-opts :limit))
         offset      (search-page-value
-                      :offset
-                      (search-option opts search-opts :offset
-                                     (:offset default-search-opts)))
+                     :offset
+                     (search-option opts search-opts :offset
+                                    (:offset default-search-opts)))
         limit       (search-page-value
-                      (if limit? :limit :top)
-                      (if limit?
-                        (search-option opts search-opts :limit
-                                       (:top default-search-opts))
-                        (search-option opts search-opts :top
-                                       (:top default-search-opts))))
+                     (if limit? :limit :top)
+                     (if limit?
+                       (search-option opts search-opts :limit
+                                      (:top default-search-opts))
+                       (search-option opts search-opts :top
+                                      (:top default-search-opts))))
         cache-pages (search-page-value
-                      :paging-cache-pages
-                      (search-option
-                        opts search-opts :paging-cache-pages
-                        (:paging-cache-pages default-search-opts)))
+                     :paging-cache-pages
+                     (search-option
+                      opts search-opts :paging-cache-pages
+                      (:paging-cache-pages default-search-opts)))
         page-end    (+ ^long offset ^long limit)
         cache-top   (if limit?
                       (* ^long limit ^long cache-pages)
@@ -852,13 +852,13 @@
             limit             (long limit)
             top               (long top)]
         (sequence
-          (comp (drop offset)
-                (take limit)
-                (display-xf this doc-filter display tms))
-          (if (zero? limit)
-            []
-            (cached-search-results this context top proximity-expansion
-                                   proximity-max-dist))))))
+         (comp (drop offset)
+               (take limit)
+               (display-xf this doc-filter display tms))
+         (if (zero? limit)
+           []
+           (cached-search-results this context top proximity-expansion
+                                  proximity-max-dist))))))
 
   IAdmin
   (re-index [this opts]
@@ -866,15 +866,15 @@
       (try
         (let [dfname (str (env-dir lmdb) u/+separator+ "search.dump")
               dos    (DataOutputStream. (FileOutputStream. ^String dfname))]
-          (nippy/freeze-to-out!
-            dos (for [[doc-id doc-ref] docs]
-                  [doc-ref (get-rawtext this doc-id)]))
+          (codec/freeze-to-out!
+           dos (for [[doc-id doc-ref] docs]
+                 [doc-ref (get-rawtext this doc-id)]))
           (.flush dos)
           (.close dos)
           (.clear-docs this)
           (let [new (new-search-engine* lmdb opts)
                 dis (DataInputStream. (FileInputStream. ^String dfname))]
-            (doseq [[doc-ref rawtext] (nippy/thaw-from-in! dis)]
+            (doseq [[doc-ref rawtext] (codec/thaw-from-in! dis)]
               (if/add-doc new doc-ref rawtext))
             (.close dis)
             (u/delete-files dfname)
@@ -1005,9 +1005,9 @@
 (defn- get-pos-info
   [^SearchEngine engine doc-id term-id]
   (wrap-cache
-    engine [:get-pos-info doc-id term-id]
-    (get-value (.-lmdb engine) (.-positions-dbi engine)
-               [doc-id term-id] :int-int :pos-info)))
+   engine [:get-pos-info doc-id term-id]
+   (get-value (.-lmdb engine) (.-positions-dbi engine)
+              [doc-id term-id] :int-int :pos-info)))
 
 (defn- get-offsets
   [engine doc-id term-id]
@@ -1037,24 +1037,24 @@
   [^SearchEngine engine {:keys [query phrases] :as context} top
    proximity-expansion proximity-max-dist]
   (wrap-cache
-    engine [:search-results query phrases top proximity-expansion
-            proximity-max-dist]
-    (raw-search-results engine context top proximity-expansion
-                        proximity-max-dist)))
+   engine [:search-results query phrases top proximity-expansion
+           proximity-max-dist]
+   (raw-search-results engine context top proximity-expansion
+                       proximity-max-dist)))
 
 (defn- get-term-info
   [^SearchEngine engine term]
   (wrap-cache
-    engine [:get-term-info term]
-    (get-value (.-lmdb engine) (.-terms-dbi engine) term
-               :string :term-info)))
+   engine [:get-term-info term]
+   (get-value (.-lmdb engine) (.-terms-dbi engine) term
+              :string :term-info)))
 
 (defn- query-term-info
   [^SearchEngine engine term]
   (wrap-cache
-    engine [:query-term-info term]
-    (get-value (.-lmdb engine) (.-terms-dbi engine) term
-               :string :query-term-info)))
+   engine [:query-term-info term]
+   (get-value (.-lmdb engine) (.-terms-dbi engine) term
+              :string :query-term-info)))
 
 (defn- term-id->term-info
   [^SearchEngine engine term-id]
@@ -1064,9 +1064,9 @@
 (defn- doc-ref->id
   [^SearchEngine engine doc-ref]
   (wrap-cache
-    engine [:doc-ref->id doc-ref]
-    (get-value (.-lmdb engine) (.-docs-dbi engine)
-               doc-ref :data :int)))
+   engine [:doc-ref->id doc-ref]
+   (get-value (.-lmdb engine) (.-docs-dbi engine)
+              doc-ref :data :int)))
 
 (defn- legacy-giant-doc-ref
   [doc-ref]
@@ -1099,13 +1099,13 @@
 (defn- doc-ref->term-ids
   [^SearchEngine engine doc-ref]
   (wrap-cache
-    engine [:doc-ref->term-ids doc-ref]
-    (let [ar (peek (get-value (.-lmdb engine)
-                              (.-docs-dbi engine)
-                              doc-ref :data :doc-info))]
-      (if (< 0 (alength ^ints ar))
-        ar
-        (term-ids-via-positions-dbi engine doc-ref)))))
+   engine [:doc-ref->term-ids doc-ref]
+   (let [ar (peek (get-value (.-lmdb engine)
+                             (.-docs-dbi engine)
+                             doc-ref :data :doc-info))]
+     (if (< 0 (alength ^ints ar))
+       ar
+       (term-ids-via-positions-dbi engine doc-ref)))))
 
 (defn- remove-doc*
   [^SearchEngine engine doc-id doc-ref]
@@ -1202,17 +1202,17 @@
                                  (boolean-array 1))
                    (when create?
                      (PendingTerm.
-                       (.incrementAndGet ^AtomicInteger (.-max-term engine))
-                       (double-array 1)
-                       (sl/sparse-arraylist)
-                       true
-                       (boolean-array 1))))]
+                      (.incrementAndGet ^AtomicInteger (.-max-term engine))
+                      (double-array 1)
+                      (sl/sparse-arraylist)
+                      true
+                      (boolean-array 1))))]
         (.put pending-terms term pending)
         pending)))
 
 (defn- pending-max-weight
   [^PendingTerm pending ^IntShortHashMap norms
-  ^IntShortHashMap added-norms]
+   ^IntShortHashMap added-norms]
   (if (aget ^booleans (.-recompute pending) 0)
     (let [^SparseIntArrayList postings (.-postings pending)
           indices ^ImmutableBitmapDataProvider (.-indices postings)
@@ -1258,7 +1258,7 @@
                     doc-terms ^HashMap (collect-terms result)
                     unique    (.size doc-terms)
                     doc-id    (.incrementAndGet
-                                ^AtomicInteger (.-max-doc engine))
+                               ^AtomicInteger (.-max-doc engine))
                     term-set  (IntHashSet.)]
                 (when include-text?
                   (.add txs (l/kv-tx :put (.-rawtext-dbi engine) doc-id
@@ -1349,7 +1349,7 @@
                           doc-terms ^HashMap (collect-terms result)
                           unique    (.size doc-terms)
                           doc-id    (.incrementAndGet
-                                      ^AtomicInteger (.-max-doc engine))
+                                     ^AtomicInteger (.-max-doc engine))
                           term-set  (IntHashSet.)]
                       (when include-text?
                         (.add txs (l/kv-tx :put rawtext-dbi doc-id doc-text
@@ -1364,8 +1364,8 @@
                               term-id (.-id pending)]
                           (let [^doubles max-weight (.-max-weight pending)]
                             (aset-double
-                              max-weight 0
-                              (add-max-weight (aget max-weight 0) tf unique)))
+                             max-weight 0
+                             (add-max-weight (aget max-weight 0) tf unique)))
                           (sl/set (.-postings pending) doc-id tf)
                           (if index-position?
                             (.add txs
@@ -1438,18 +1438,18 @@
   [^SearchEngine engine ^AtomicInteger max-doc tokens]
   (into []
         (comp
-          (map (fn [[term freq]]
-                 (when-let [[id mw ^SparseIntArrayList sl]
-                            (query-term-info engine term)]
-                   (let [df (sl/size sl)]
-                     {:df df
-                      :id id
-                      :mw mw
-                      :sl sl
-                      :tm term
-                      :wq (* ^double (tf* freq)
-                             ^double (idf df (.get max-doc)))}))))
-          (filter map?))
+         (map (fn [[term freq]]
+                (when-let [[id mw ^SparseIntArrayList sl]
+                           (query-term-info engine term)]
+                  (let [df (sl/size sl)]
+                    {:df df
+                     :id id
+                     :mw mw
+                     :sl sl
+                     :tm term
+                     :wq (* ^double (tf* freq)
+                            ^double (idf df (.get max-doc)))}))))
+         (filter map?))
         (frequencies tokens)))
 
 (defn- hydrate-query
@@ -1475,11 +1475,11 @@
   (when-let [doc-ref (get-doc-ref engine doc-filter result)]
     [doc-ref
      (sequence
-       (comp (map (fn [tid]
-                    (when-let [offsets (get-offsets engine doc-id tid)]
-                      [(terms tid) (apply vector offsets)])))
-             (remove nil?))
-       (keys terms))]))
+      (comp (map (fn [tid]
+                   (when-let [offsets (get-offsets engine doc-id tid)]
+                     [(terms tid) (apply vector offsets)])))
+            (remove nil?))
+      (keys terms))]))
 
 (defn- get-rawtext
   [^SearchEngine engine doc-id]
@@ -1498,11 +1498,11 @@
      (get-value (.-lmdb engine) (.-rawtext-dbi engine)
                 doc-id :int :string)
      (sequence
-       (comp (map (fn [tid]
-                 (when-let [offsets (get-offsets engine doc-id tid)]
-                   [(terms tid) (apply vector offsets)])))
-          (remove nil?))
-       (keys terms))]))
+      (comp (map (fn [tid]
+                   (when-let [offsets (get-offsets engine doc-id tid)]
+                     [(terms tid) (apply vector offsets)])))
+            (remove nil?))
+      (keys terms))]))
 
 (defn- display-xf
   [^SearchEngine engine doc-filter display tms]
@@ -1614,8 +1614,8 @@
 (defn- resolve-analyzer-udf
   [udf-registry domain k value]
   (let [udf-desc (udf/descriptor-or-registered udf-registry
-                                                (analyzer-udf-kinds k)
-                                                value)
+                                               (analyzer-udf-kinds k)
+                                               value)
         callable (udf/materialize udf-registry
                                   {:feature :fulltext-analyzer
                                    :domain  domain
@@ -1659,29 +1659,29 @@
                  index-position? (default-opts :index-position?)
                  include-text?   (default-opts :include-text?)
                  search-opts     (default-opts :search-opts)}} opts]
-   (let [terms-dbi     (str domain "/" c/terms)
-         docs-dbi      (str domain "/" c/docs)
-         positions-dbi (str domain "/" c/positions)
-         rawtext-dbi   (str domain "/" c/rawtext)]
-     (open-dbis lmdb terms-dbi docs-dbi positions-dbi rawtext-dbi)
-     (let [[max-doc norms docs] (init-docs lmdb docs-dbi)
-           [max-term terms]     (init-terms lmdb terms-dbi)]
-       (->SearchEngine lmdb
-                       analyzer
-                       (or query-analyzer analyzer)
-                       terms-dbi
-                       docs-dbi
-                       positions-dbi
-                       rawtext-dbi
-                       terms     ;; term-id -> term
-                       docs      ;; doc-id -> doc-ref
-                       norms     ;; doc-id -> norm
-                       (LRUCache. 10000)
-                       (AtomicInteger. max-doc)
-                       (AtomicInteger. max-term)
-                       index-position?
-                       include-text?
-                       search-opts))))))
+     (let [terms-dbi     (str domain "/" c/terms)
+           docs-dbi      (str domain "/" c/docs)
+           positions-dbi (str domain "/" c/positions)
+           rawtext-dbi   (str domain "/" c/rawtext)]
+       (open-dbis lmdb terms-dbi docs-dbi positions-dbi rawtext-dbi)
+       (let [[max-doc norms docs] (init-docs lmdb docs-dbi)
+             [max-term terms]     (init-terms lmdb terms-dbi)]
+         (->SearchEngine lmdb
+                         analyzer
+                         (or query-analyzer analyzer)
+                         terms-dbi
+                         docs-dbi
+                         positions-dbi
+                         rawtext-dbi
+                         terms     ;; term-id -> term
+                         docs      ;; doc-id -> doc-ref
+                         norms     ;; doc-id -> norm
+                         (LRUCache. 10000)
+                         (AtomicInteger. max-doc)
+                         (AtomicInteger. max-term)
+                         index-position?
+                         include-text?
+                         search-opts))))))
 
 (defn new-search-engine
   ([lmdb]
@@ -1802,30 +1802,26 @@
           :or   {analyzer        a/en-analyzer
                  index-position? false
                  include-text?   false}} opts]
-   (let [terms-dbi     (str domain "/" c/terms)
-         docs-dbi      (str domain "/" c/docs)
-         positions-dbi (str domain "/" c/positions)
-         rawtext-dbi   (str domain "/" c/rawtext)]
-     (open-dbis lmdb terms-dbi docs-dbi positions-dbi rawtext-dbi)
-     (->IndexWriter lmdb
-                    analyzer
-                    terms-dbi
-                    docs-dbi
-                    positions-dbi
-                    rawtext-dbi
-                    (AtomicInteger. (init-max-id lmdb docs-dbi))
-                    (AtomicInteger. (init-max-id lmdb terms-dbi))
-                    index-position?
-                    include-text?
-                    (FastList.)
-                    (HashMap.))))))
-
-
+     (let [terms-dbi     (str domain "/" c/terms)
+           docs-dbi      (str domain "/" c/docs)
+           positions-dbi (str domain "/" c/positions)
+           rawtext-dbi   (str domain "/" c/rawtext)]
+       (open-dbis lmdb terms-dbi docs-dbi positions-dbi rawtext-dbi)
+       (->IndexWriter lmdb
+                      analyzer
+                      terms-dbi
+                      docs-dbi
+                      positions-dbi
+                      rawtext-dbi
+                      (AtomicInteger. (init-max-id lmdb docs-dbi))
+                      (AtomicInteger. (init-max-id lmdb terms-dbi))
+                      index-position?
+                      include-text?
+                      (FastList.)
+                      (HashMap.))))))
 
 (comment
   (def lmdb (time (if/open-kv "search-bench/data/wiki-datalevin-all")))
   (def engine (time (new-search-engine lmdb)))
   (doc-count engine)
-  (search engine "debian linux")
-
-  )
+  (search engine "debian linux"))

--- a/src/datalevin/sparselist.clj
+++ b/src/datalevin/sparselist.clj
@@ -13,9 +13,10 @@
   (:require
    [datalevin.ints :as i]
    [datalevin.interface :refer [compress uncompress]]
-   [taoensso.nippy :as nippy])
+   [s-exp.hako.ext :as hext])
   (:import
-   [java.io Writer DataInput DataOutput]
+   [com.s_exp.hako Reader]
+   [java.io Writer DataInput DataOutput ByteArrayOutputStream DataOutputStream ByteArrayInputStream DataInputStream]
    [java.nio ByteBuffer]
    [datalevin.utl GrowingIntArray]
    [org.roaringbitmap ImmutableBitmapDataProvider RoaringBitmap]
@@ -75,52 +76,59 @@
          (.equals indices (.-indices ^SparseIntArrayList other))
          (.equals items (.-items ^SparseIntArrayList other)))))
 
-(nippy/extend-freeze
-  RoaringBitmap :dtlv/bm
-  [^RoaringBitmap x ^DataOutput out]
-  (.serialize x out))
+(hext/register-user-tag!
+ 0x10000005                             ; private range, subtag 5 = RoaringBitmap
+ RoaringBitmap
+ (fn write-bm [^com.s_exp.hako.Writer w ^RoaringBitmap x]
+   (let [baos (ByteArrayOutputStream.)
+         dos  (DataOutputStream. baos)]
+     (.serialize x ^DataOutput dos)
+     (.flush dos)
+     (.writeBytes w (.toByteArray baos))))
+ (fn read-bm [^Reader r]
+   (let [tag (.getByte r)
+         low (bit-and tag 0x0F)
+         n   (.readTierPayload r (int low))
+         arr (.getBytes r (int n))
+         dis (DataInputStream. (ByteArrayInputStream. arr))]
+     (doto (RoaringBitmap.) (.deserialize ^DataInput dis)))))
 
-(nippy/extend-freeze
-    GrowingIntArray :dtlv/gia
-    [^GrowingIntArray x ^DataOutput out]
-  (let [ar        (.toArray  x)
-        osize     (alength ar)
-        comp?     (< 3 osize)
-        ^ints car (if comp?
-                    (compress i/int-compressor ar)
-                    ar)
-        size      (alength car)]
-    (.writeInt out (if comp? (- size) size))
-    (dotimes [i size] (.writeInt out (aget car i)))))
+(hext/register-user-tag!
+ 0x10000006                             ; private range, subtag 6 = GrowingIntArray
+ GrowingIntArray
+ (fn write-gia [^com.s_exp.hako.Writer w ^GrowingIntArray x]
+   (let [ar        (.toArray x)
+         osize     (alength ar)
+         comp?     (< 3 osize)
+         ^ints car (if comp?
+                     (compress i/int-compressor ar)
+                     ar)
+         size      (alength car)]
+     (.putI32 w (if comp? (- size) size))
+     (dotimes [i size] (.putI32 w (aget car i)))))
+ (fn read-gia [^Reader r]
+   (let [csize (.getI32 r)
+         comp? (neg? csize)
+         size  (if comp? (- csize) csize)
+         car   (int-array size)
+         items (GrowingIntArray.)]
+     (dotimes [i size] (aset car i (.getI32 r)))
+     (.addAll items
+              (if comp?
+                (uncompress i/int-compressor car)
+                car))
+     items)))
 
-(nippy/extend-freeze
-  SparseIntArrayList :dtlv/sial
-  [^SparseIntArrayList x ^DataOutput out]
-  (nippy/freeze-to-out! out (.-items x))
-  (nippy/freeze-to-out! out (.-indices x)))
-
-(nippy/extend-thaw
-  :dtlv/bm [^DataInput in]
-  (doto (RoaringBitmap.) (.deserialize in)))
-
-(nippy/extend-thaw
-    :dtlv/gia [^DataInput in]
-  (let [csize (.readInt in)
-        comp? (neg? csize)
-        size  (if comp? (- csize) csize)
-        car   (int-array size)
-        items (GrowingIntArray.)]
-    (dotimes [i size] (aset car i (.readInt in)))
-    (.addAll items
-             (if comp?
-               (uncompress i/int-compressor car)
-               car))
-    items))
-
-(nippy/extend-thaw
-  :dtlv/sial [^DataInput in]
-  (let [items (nippy/thaw-from-in! in)]
-    (->SparseIntArrayList (nippy/thaw-from-in! in) items)))
+(hext/register-user-tag!
+ 0x10000007                             ; private range, subtag 7 = SparseIntArrayList
+ SparseIntArrayList
+ (fn write-sial [^com.s_exp.hako.Writer w ^SparseIntArrayList x]
+   (.writeAny w (.-items x))
+   (.writeAny w (.-indices x)))
+ (fn read-sial [^Reader r]
+   (let [items (.readAny r)
+         indices (.readAny r)]
+     (->SparseIntArrayList indices items))))
 
 (defn sparse-arraylist
   ([]
@@ -136,7 +144,7 @@
        (when (and ks vs)
          (set ssl (first ks) (first vs))
          (recur (next ks) (next vs))))
-     ssl)) )
+     ssl)))
 
 (defn deserialize-off-heap
   "Deserialize a read-only sparse list with its bitmap backed by direct memory."

--- a/src/datalevin/sparselist.clj
+++ b/src/datalevin/sparselist.clj
@@ -76,16 +76,28 @@
          (.equals indices (.-indices ^SparseIntArrayList other))
          (.equals items (.-items ^SparseIntArrayList other)))))
 
+;; RoaringBitmap serializes through a DataOutputStream contract we can't
+;; easily bridge to hako's segment. Cache the intermediate stream per
+;; thread so we don't pay the alloc on every bitmap encode.
+(def ^:private ^ThreadLocal tl-bm-baos
+  (proxy [ThreadLocal] []
+    (initialValue [] (ByteArrayOutputStream. 256))))
+
 (hext/register-user-tag!
- 0x10000005                             ; private range, subtag 5 = RoaringBitmap
+ 5                                      ; subtag 5 = RoaringBitmap (wire id 0x10000005)
  RoaringBitmap
  (fn write-bm [^com.s_exp.hako.Writer w ^RoaringBitmap x]
-   (let [baos (ByteArrayOutputStream.)
+   (let [^ByteArrayOutputStream baos (.get tl-bm-baos)
+         _    (.reset baos)
          dos  (DataOutputStream. baos)]
      (.serialize x ^DataOutput dos)
      (.flush dos)
      (.writeBytes w (.toByteArray baos))))
  (fn read-bm [^Reader r]
+   ;; Manual tier decode: hako's writeBytes emits `[M_BYTES tag][tier
+   ;; code][len bytes]`. `.readAny` would work but returns a fresh
+   ;; byte[]; this path reads the payload straight into `getBytes` and
+   ;; feeds RoaringBitmap.deserialize without the readAny dispatch.
    (let [tag (.getByte r)
          low (bit-and tag 0x0F)
          n   (.readTierPayload r (int low))
@@ -94,7 +106,7 @@
      (doto (RoaringBitmap.) (.deserialize ^DataInput dis)))))
 
 (hext/register-user-tag!
- 0x10000006                             ; private range, subtag 6 = GrowingIntArray
+ 6                                      ; subtag 6 = GrowingIntArray (wire id 0x10000006)
  GrowingIntArray
  (fn write-gia [^com.s_exp.hako.Writer w ^GrowingIntArray x]
    (let [ar        (.toArray x)
@@ -120,7 +132,7 @@
      items)))
 
 (hext/register-user-tag!
- 0x10000007                             ; private range, subtag 7 = SparseIntArrayList
+ 7                                      ; subtag 7 = SparseIntArrayList (wire id 0x10000007)
  SparseIntArrayList
  (fn write-sial [^com.s_exp.hako.Writer w ^SparseIntArrayList x]
    (.writeAny w (.-items x))

--- a/src/datalevin/spill.clj
+++ b/src/datalevin/spill.clj
@@ -16,11 +16,11 @@
    [datalevin.util :as u]
    [datalevin.lmdb :as l]
    [datalevin.interface :as i]
-   [taoensso.nippy :as nippy]
+   [s-exp.hako.ext :as hext]
    [clojure.set :as set])
   (:import
+   [com.s_exp.hako Reader Writer]
    [java.util Iterator List UUID NoSuchElementException Map Set Collection]
-   [java.io DataInput DataOutput]
    [java.lang.ref Cleaner Cleaner$Cleanable]
    [java.lang.management ManagementFactory]
    [javax.management NotificationEmitter NotificationListener Notification]
@@ -50,9 +50,9 @@
     (let [^NotificationListener listener
           (reify NotificationListener
             (^void handleNotification [_ ^Notification notif _]
-             (when (= (.getType notif)
-                      GarbageCollectionNotificationInfo/GARBAGE_COLLECTION_NOTIFICATION)
-               (set-memory-pressure))))]
+              (when (= (.getType notif)
+                       GarbageCollectionNotificationInfo/GARBAGE_COLLECTION_NOTIFICATION)
+                (set-memory-pressure))))]
       (vswap! listeners assoc gcbean listener)
       (.addNotificationListener gcbean listener nil nil))))
 
@@ -304,7 +304,7 @@
 
   (cons [_ _]
     (throw (UnsupportedOperationException.
-             "Changing SpillableVector.SVecSeq is not supported")))
+            "Changing SpillableVector.SVecSeq is not supported")))
 
   (count [_] (- (count v) i))
 
@@ -329,7 +329,7 @@
 
   (cons [_ _]
     (throw (UnsupportedOperationException.
-             "Changing SpillableVector.RSVecSeq is not supported")))
+            "Changing SpillableVector.RSVecSeq is not supported")))
 
   (count [_] (inc i))
 
@@ -362,24 +362,22 @@
 (defn map-sv
   [f sv]
   (reduce
-    (fn [^SpillableVector acc r] (.cons acc (f r)))
-    (new-spillable-vector)
-    sv))
+   (fn [^SpillableVector acc r] (.cons acc (f r)))
+   (new-spillable-vector)
+   sv))
 
-(nippy/extend-freeze
-    SpillableVector :spillable-vec
-    [^SpillableVector x ^DataOutput out]
-  (let [n (count x)]
-    (.writeLong out n)
-    (dotimes [i n] (nippy/freeze-to-out! out (nth x i)))))
-
-(nippy/extend-thaw
-  :spillable-vec
-  [^DataInput in]
-  (let [n                   (.readLong in)
-        ^SpillableVector vs (new-spillable-vector)]
-    (dotimes [_ n] (.cons vs (nippy/thaw-from-in! in)))
-    vs))
+(hext/register-user-tag!
+ 0x10000002                             ; private range, subtag 2 = spillable-vec
+ SpillableVector
+ (fn write-spillable-vec [^Writer w ^SpillableVector x]
+   (let [n (count x)]
+     (.putI64 w n)
+     (dotimes [i n] (.writeAny w (nth x i)))))
+ (fn read-spillable-vec [^Reader r]
+   (let [n (.getI64 r)
+         ^SpillableVector vs (new-spillable-vector)]
+     (dotimes [_ n] (.cons vs (.readAny r)))
+     vs)))
 
 (deftype SpillableMap [^long spill-threshold
                        ^String spill-root
@@ -550,15 +548,13 @@
      (doseq [[k v] m] (assoc smap k v))
      smap)))
 
-(nippy/extend-freeze
-  SpillableMap :spillable-map
-  [^SpillableMap x ^DataOutput out]
-  (nippy/freeze-to-out! out (into {} x)))
-
-(nippy/extend-thaw
-  :spillable-map
-  [^DataInput in]
-  (new-spillable-map (nippy/thaw-from-in! in)))
+(hext/register-user-tag!
+ 0x10000003                             ; private range, subtag 3 = spillable-map
+ SpillableMap
+ (fn write-spillable-map [^Writer w ^SpillableMap x]
+   (.writeAny w (into {} x)))
+ (fn read-spillable-map [^Reader r]
+   (new-spillable-map (.readAny r))))
 
 (deftype SpillableSet [^SpillableMap impl
                        ^:unsynchronized-mutable meta]
@@ -574,7 +570,7 @@
 
   (count [_] (count impl))
 
-  (contains[_ o] (.containsKey impl o))
+  (contains [_ o] (.containsKey impl o))
 
   (cons [this o] (.put impl o c/slash) this)
 
@@ -647,12 +643,10 @@
      (doseq [e s] (.put impl e c/slash))
      (SpillableSet. impl nil))))
 
-(nippy/extend-freeze
-  SpillableSet :spillable-set
-  [^SpillableSet x ^DataOutput out]
-  (nippy/freeze-to-out! out (into #{} x)))
-
-(nippy/extend-thaw
-  :spillable-set
-  [^DataInput in]
-  (new-spillable-set (nippy/thaw-from-in! in)))
+(hext/register-user-tag!
+ 0x10000004                             ; private range, subtag 4 = spillable-set
+ SpillableSet
+ (fn write-spillable-set [^Writer w ^SpillableSet x]
+   (.writeAny w (into #{} x)))
+ (fn read-spillable-set [^Reader r]
+   (new-spillable-set (.readAny r))))

--- a/src/datalevin/spill.clj
+++ b/src/datalevin/spill.clj
@@ -367,12 +367,15 @@
    sv))
 
 (hext/register-user-tag!
- 0x10000002                             ; private range, subtag 2 = spillable-vec
+ 2                                      ; subtag 2 = spillable-vec (wire id 0x10000002)
  SpillableVector
  (fn write-spillable-vec [^Writer w ^SpillableVector x]
-   (let [n (count x)]
-     (.putI64 w n)
-     (dotimes [i n] (.writeAny w (nth x i)))))
+   ;; Iterate via the SpillableVector iterator — `nth` on a spilled
+   ;; backing is O(seek) per index, so a `dotimes`+`nth` loop is
+   ;; quadratic on the disk-resident portion.
+   (.putI64 w (count x))
+   (let [it (.iterator x)]
+     (while (.hasNext it) (.writeAny w (.next it)))))
  (fn read-spillable-vec [^Reader r]
    (let [n (.getI64 r)
          ^SpillableVector vs (new-spillable-vector)]
@@ -549,12 +552,22 @@
      smap)))
 
 (hext/register-user-tag!
- 0x10000003                             ; private range, subtag 3 = spillable-map
+ 3                                      ; subtag 3 = spillable-map (wire id 0x10000003)
  SpillableMap
  (fn write-spillable-map [^Writer w ^SpillableMap x]
-   (.writeAny w (into {} x)))
+   ;; Stream entries instead of materialising `(into {} x)` — spilled
+   ;; maps would otherwise pull the entire disk backing into heap here.
+   (.putI64 w (count x))
+   (let [it (.iterator x)]
+     (while (.hasNext it)
+       (let [^java.util.Map$Entry e (.next it)]
+         (.writeAny w (.getKey e))
+         (.writeAny w (.getValue e))))))
  (fn read-spillable-map [^Reader r]
-   (new-spillable-map (.readAny r))))
+   (let [n (.getI64 r)
+         smap (new-spillable-map)]
+     (dotimes [_ n] (assoc smap (.readAny r) (.readAny r)))
+     smap)))
 
 (deftype SpillableSet [^SpillableMap impl
                        ^:unsynchronized-mutable meta]
@@ -644,9 +657,16 @@
      (SpillableSet. impl nil))))
 
 (hext/register-user-tag!
- 0x10000004                             ; private range, subtag 4 = spillable-set
+ 4                                      ; subtag 4 = spillable-set (wire id 0x10000004)
  SpillableSet
  (fn write-spillable-set [^Writer w ^SpillableSet x]
-   (.writeAny w (into #{} x)))
+   ;; Stream elements instead of `(into #{} x)` — spilled sets would
+   ;; otherwise materialise the whole disk backing into a heap set.
+   (.putI64 w (count x))
+   (let [it (.iterator x)]
+     (while (.hasNext it) (.writeAny w (.next it)))))
  (fn read-spillable-set [^Reader r]
-   (new-spillable-set (.readAny r))))
+   (let [n (.getI64 r)
+         ^SpillableSet s (new-spillable-set)]
+     (dotimes [_ n] (conj s (.readAny r)))
+     s)))

--- a/src/datalevin/vector.clj
+++ b/src/datalevin/vector.clj
@@ -20,7 +20,7 @@
    [datalevin.interface :as i]
    [datalevin.txlog :as txlog]
    [clojure.string :as s]
-   [taoensso.nippy :as nippy])
+   [datalevin.hako-codec :as codec])
   (:import
    [datalevin.dtlvnative DTLV DTLV$usearch_index_t]
    [datalevin.cpp VecIdx VecIdx$SearchResult VecIdx$IndexInfo]
@@ -68,12 +68,12 @@
   [dimensions metric-key quantization connectivity expansion-add
    expansion-search]
   (VecIdx/create
-    ^long dimensions
-    ^int (metric-key->type metric-key)
-    ^int (scalar-kind quantization)
-    ^long connectivity
-    ^long expansion-add
-    ^long expansion-search))
+   ^long dimensions
+   ^int (metric-key->type metric-key)
+   ^int (scalar-kind quantization)
+   ^long connectivity
+   ^long expansion-add
+   ^long expansion-search))
 
 (defn- ->array
   [quantization vec-data]
@@ -435,7 +435,7 @@
               (let [offset-l (unchecked-multiply (long i) (long chunk-size))
                     offset   (int offset-l)
                     end      (int (min (unchecked-add offset-l
-                                                     (long chunk-size))
+                                                      (long chunk-size))
                                        total-bytes))
                     chunk  (Arrays/copyOfRange all-bytes offset end)]
                 (.add txs (l/kv-tx :put c/vec-index-dbi
@@ -449,7 +449,7 @@
           (VecIdx/save index (.getAbsolutePath tmp-file))
           (with-open [fis (FileInputStream. tmp-file)]
             (let [read-buf (byte-array (int (min (long chunk-size)
-                                             (long Integer/MAX_VALUE))))]
+                                                 (long Integer/MAX_VALUE))))]
               (loop [chunk-id 0]
                 (let [n (.read fis read-buf)]
                   (when (pos? n)
@@ -690,7 +690,7 @@
           (let [commit-lsn (txn-log-next-lsn lmdb)
                 meta-op    (replay-floor-put-tx lmdb domain commit-lsn)
                 txs        (cond-> [(l/kv-tx :put vecs-dbi vec-ref id
-                                              :data :id)]
+                                             :data :id)]
                              (some? meta-op) (conj meta-op))]
             (i/transact-kv lmdb txs))
           (try
@@ -773,7 +773,7 @@
                     (try
                       (i/transact-kv
                        lmdb [(l/kv-tx :put-list vecs-dbi stored-ref ids
-                                              :data :id)])
+                                      :data :id)])
                       (catch Throwable rollback-e
                         (throw (ex-info "Fail to rollback vector ref mapping"
                                         {:vec-ref stored-ref :ids ids}
@@ -853,9 +853,9 @@
   (search-vec [this query-vec]
     (.search-vec this query-vec {}))
   (search-vec [_ query-vec {:keys [display top vec-filter]
-                               :or   {display    (:display search-opts)
-                                      top        (:top search-opts)
-                                      vec-filter (:vec-filter search-opts)}}]
+                            :or   {display    (:display search-opts)
+                                   top        (:top search-opts)
+                                   vec-filter (:vec-filter search-opts)}}]
     (let [rlock (.readLock vec-lock)]
       (.lock rlock)
       (try
@@ -874,15 +874,15 @@
     (try
       (let [dfname (str fname ".dump")
             dos    (DataOutputStream. (FileOutputStream. ^String dfname))]
-        (nippy/freeze-to-out!
-          dos (for [[vec-id vec-ref] vecs]
-                [vec-ref (get-vec* index vec-id quantization dimensions)]))
+        (codec/freeze-to-out!
+         dos (for [[vec-id vec-ref] vecs]
+               [vec-ref (get-vec* index vec-id quantization dimensions)]))
         (.flush dos)
         (.close dos)
         (.clear-vecs this)
         (let [new (new-vector-index lmdb opts)
               dis (DataInputStream. (FileInputStream. ^String dfname))]
-          (doseq [[vec-ref vec-data] (nippy/thaw-from-in! dis)]
+          (doseq [[vec-ref vec-data] (codec/thaw-from-in! dis)]
             (i/add-vec new vec-ref vec-data))
           (.close dis)
           (u/delete-files dfname)
@@ -1060,25 +1060,25 @@
                    :vec-checkpoint-bytes
                    (nonneg-long (or (:total-bytes meta-val) 0))
                    :vec-checkpoint-failure-count 0})]
-      (let [vi (->VectorIndex lmdb
-                              (volatile! false)
-                              index
-                              fname
-                              domain
-                              dimensions
-                              metric-type
-                              quantization
-                              connectivity
-                              expansion-add
-                              expansion-search
-                              vecs-dbi
-                              vecs
-                              (AtomicLong. max-vec-id)
-                              search-opts
-                              checkpoint-stats
-                              (ReentrantReadWriteLock.))]
-        (swap! l/vector-indices assoc fname vi)
-        vi)))))
+        (let [vi (->VectorIndex lmdb
+                                (volatile! false)
+                                index
+                                fname
+                                domain
+                                dimensions
+                                metric-type
+                                quantization
+                                connectivity
+                                expansion-add
+                                expansion-search
+                                vecs-dbi
+                                vecs
+                                (AtomicLong. max-vec-id)
+                                search-opts
+                                checkpoint-stats
+                                (ReentrantReadWriteLock.))]
+          (swap! l/vector-indices assoc fname vi)
+          vi)))))
 
 (defn new-vector-index
   [lmdb opts]


### PR DESCRIPTION
# Swap Nippy for hako (exploratory)

Exploratory. Hako is still pre-1.0 and moving/improving fast — the wire format
isn't frozen yet and the API can shift between alphas. I am aiming at stabilizing it soon however. 
Don't treat this
branch as merge-ready as-is. What it's meant to show is where a
Datalevin-on-hako codec could land: what the numbers look like, what
the migration story is, what the friction points are.

Replaces Nippy with [hako](https://github.com/mpenet/meep) as the codec
for LMDB records, dumps, spillable colls, records, and the rest of the
serialization surface. Hako is a FFM-native binary serializer built on
JDK 25 `MemorySegment` — reused writer/reader per thread, zero on-heap
per encode once warm.

## Why bother

A few things add up:

- Hako's per-message symbol table collapses repeated keywords/symbols
  to 1-byte symrefs. Datom-heavy payloads shrink 40% or so on the wire.
- The writer lives in an off-heap arena, so per-call heap alloc drops
  to zero once the writer is warm.
- LMDB's `ByteBuffer` accepts a `MemorySegment` copy directly — no
  intermediate `byte[]` bounce like Nippy's `DataOutput` contract
  forces.
- Numbers below.

## Files touched

Codec swap in each of the following, all pointing at
`datalevin.hako-codec`:

- `datom.clj`, `entity.clj`
- `spill.clj` (SpillableVector/Map/Set)
- `sparselist.clj` (SparseIntArrayList, RoaringBitmap, GrowingIntArray)
- `interpret.clj` (inter-fn source)
- `bits.clj`, `dump.clj`, `vector.clj`
- `constants.clj`, `txlog/meta.clj`, `client_op.clj`, `storage.clj`
- `hako_codec.clj` (new) — signature-compatible with
  `nippy/freeze-to-out!` / `thaw-from-in!` / `fast-freeze` / `fast-thaw`,
  plus a `put-data-into-buffer!` that skips the byte[] intermediate on
  LMDB writes.

Deps bump: `com.s-exp/hako 1.0.0-alpha47`. Nippy stays around as a
transitive for `#nippy/tag` reader-literal compat during migration but
none of the codec paths hit it.

## Benchmarks

Datom codec (`clj -M:bench -m hako-vs-nippy`, hako vs `nippy-fast`):

| payload      | metric | Nippy fast | hako    | ratio |
|--------------|--------|-----------:|--------:|:-----:|
| single datom | encode | 211 ns     | 100 ns  | 2.1× |
| single datom | decode | 189 ns     | 130 ns  | 1.5× |
| 100 datoms   | encode | 19.9 µs    | 11.2 µs | 1.8× |
| 100 datoms   | decode | 22.9 µs    | 12.1 µs | 1.9× |
| 1000 datoms  | encode | 218 µs     | 113 µs  | 1.9× |
| 1000 datoms  | decode | 244 µs     | 117 µs  | 2.1× |

Alloc (`clj -M:bench -m datom-alloc`, reused reader/writer):

| payload      | op     | Nippy fast | hako     | ratio |
|--------------|--------|-----------:|---------:|:-----:|
| single datom | encode | 416 B      | 192 B    | 2.2× |
| single datom | decode | 696 B      | 320 B    | 2.2× |
| 100 datoms   | encode | 21955 B    | 16440 B  | 1.3× |
| 100 datoms   | decode | 49461 B    | 25808 B  | 1.9× |
| 1000 datoms  | encode | 261408 B   | 164040 B | 1.6× |
| 1000 datoms  | decode | 521168 B   | 264192 B | 2.0× |

Wire size:

| payload      | Nippy fast | hako   | Δ            |
|--------------|-----------:|-------:|:------------:|
| single       | 47 B       | 37 B   | -21%          |
| 100 datoms   | 4548 B     | 2574 B | -43%          |
| 1000 datoms  | 47340 B    | 26347 B | -44%         |

E2E datalevin workloads (`clj -M:bench -m e2e-alloc`) barely move —
transact and query paths dominate the alloc budget. Range scan drops
~7% (the one workload where Datom decode is actually a hot fraction).

## Dump/restore

`freeze-to-out!` / `thaw-from-in!` wrap the hako payload with zstd
(level 3, via `com.github.luben.zstd.Zstd` already in deps). Matches
what Nippy's default compressed `freeze` does. On a synthetic 10k-entry
`[eid tuple]` dump:

| codec              | size    |
|--------------------|--------:|
| Nippy freeze (LZ4) | 828 KB  |
| hako + zstd        | 41 KB   |

The gap is bigger than raw compression ratio would suggest because
hako's own symref dedup runs first — zstd is operating on already-tight
input. Level 3 is a guess; the ratio at higher levels is probably not
worth the encode CPU here.

Hot LMDB records go through `put-data-into-buffer!`, not
`freeze-to-out!`, so they stay uncompressed.

## Compatibility

- Wire format is different from Nippy — Existing DBs need `datalevin.dump/dump-database` on
  the old version, then `dump-in-database` on the new. Roughly 4 sec
  round-trip on a 100k-datom DB on M2 laptop, but obviously depends on
  the data.

## Migration notes

If you have consumers using `nippy/freeze` / `nippy/thaw` directly at
some API boundary (e.g. a custom serialization hook or a Redis blob),
those need to move to `datalevin.hako-codec/freeze` / `thaw`. Signatures
match, drop-in replacement.

Old DBs won't open — dump/restore is the migration story for now. A
transparent hako-or-nippy reader on `open` would be nice but I haven't
built it; happy to if it's a blocker.

## Not done / open

- Zero-downtime migration (auto-detect nippy vs hako on open). Not sure it’s desirable but maybe.
- Registering more user value types with hako's user-tag registry
  (currently just the ones we already ship).
- Try zstd level 1 vs 3 on real dump sizes — 3 was picked as a
  reasonable default without benching.
- it’s a first-pass/make-it-work pr, it needs some cleaning up. 
- Deeper adoption of FFM could open more optimizations at other levels, I haven’t explored these in detail (yet).
